### PR TITLE
allow parameters to be numbers and booleans as well

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -80,11 +80,12 @@ report_list <- function(root, ref) {
 ##'   state root :: root
 report_parameters <- function(root, ref, name) {
   params <- get_report_parameters(name, ref, root)
+  browser()
   lapply(names(params), function(param_name) {
     value <- params[[param_name]]
     list(
       name = scalar(param_name),
-      value = if (is.null(value)) value else scalar(as.character(value))
+      value = if (is.null(value)) value else scalar(value)
     )
   })
 }

--- a/R/api.R
+++ b/R/api.R
@@ -80,7 +80,6 @@ report_list <- function(root, ref) {
 ##'   state root :: root
 report_parameters <- function(root, ref, name) {
   params <- get_report_parameters(name, ref, root)
-  browser()
   lapply(names(params), function(param_name) {
     value <- params[[param_name]]
     list(

--- a/docker/test/examples/parameters/parameters.R
+++ b/docker/test/examples/parameters/parameters.R
@@ -1,3 +1,3 @@
-orderly2::orderly_parameters(a = NULL)
-data <- list(a = a)
+orderly2::orderly_parameters(a = NULL, b = 2)
+data <- list(a = a, b = b)
 write.csv(data, "parameters.csv")

--- a/inst/schema/report_parameters.json
+++ b/inst/schema/report_parameters.json
@@ -5,7 +5,7 @@
         "type": "object",
         "properties": {
             "name": { "type": "string" },
-            "value": { "type": [ "string", "null" ] }
+            "value": { "type": [ "string", "null", "boolean", "number", "integer" ] }
         },
         "required": [ "name", "value" ],
         "additionalProperties": false

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -82,7 +82,7 @@ test_that("can get parameters for a report", {
   expect_equal(res$status_code, 200)
   expect_equal(res$data, list(
     list(name = scalar("a"), value = NULL),
-    list(name = scalar("b"), value = scalar("2")),
+    list(name = scalar("b"), value = scalar(2)),
     list(name = scalar("c"), value = NULL)
   ))
 })

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -61,7 +61,7 @@ test_that("can get parameters", {
   expect_null(dat$errors)
   expect_equal(dat$data, list(
     list(name = "a", value = NULL),
-    list(name = "b", value = "2"),
+    list(name = "b", value = 2),
     list(name = "c", value = NULL)
   ))
 })


### PR DESCRIPTION
It was just the `as.character` transforming everything into a string