### PR TITLE
Mrc-5708 Return taskId as part of status endpoint

### DIFF
--- a/R/queue.R
+++ b/R/queue.R
@@ -95,7 +95,8 @@ Queue <- R6::R6Class("Queue", # nolint
           timeStarted = scalar(tasks_times[task_ids[index], 2]),
           timeComplete = scalar(tasks_times[task_ids[index], 3]),
           packetId = if (statuses[index] == "COMPLETE") scalar(rrq::rrq_task_result(task_ids[index], controller = self$controller)) else NULL,
-          logs = if (include_logs) rrq::rrq_task_log(task_ids[index], controller = self$controller) else NULL
+          logs = if (include_logs) rrq::rrq_task_log(task_ids[index], controller = self$controller) else NULL,
+          taskId = scalar(task_ids[index])
         )
       })
     },

--- a/inst/schema/report_run_status_response.json
+++ b/inst/schema/report_run_status_response.json
@@ -31,9 +31,12 @@
             },
             "packetId": {
                 "type": ["string", "null"]
+            },
+            "taskId": {
+              "type": "string"
             }
         },
-        "required": ["timeQueued", "timeStarted", "queuePosition", "logs", "status", "packetId"],
+        "required": ["timeQueued", "timeStarted", "queuePosition", "logs", "status", "packetId", "taskId"],
         "additionalProperties": false
     }
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -180,5 +180,6 @@ test_that("can get statuses of jobs", {
     expect_equal(scalar(task_times[2]), task_status$timeStarted)
     expect_equal(scalar(task_times[3]), task_status$timeComplete)
     expect_equal(get_task_logs(task_ids[[i]], queue$controller), unlist(task_status$logs))
+    expect_equal(scalar(task_ids[[i]]), task_status$taskId)
   }
 })

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -148,6 +148,7 @@ test_that("can get statuses on complete report runs with logs", {
     expect_null(status$queuePosition)
     expect_equal(status$packetId, scalar(get_task_result(task_ids[[i]], q$controller)))
     expect_equal(status$logs, get_task_logs(task_ids[[i]], q$controller))
+    expect_equal(scalar(task_ids[[i]]), status$taskId)
   }
 })
 
@@ -169,6 +170,7 @@ test_that("can get statuses wihtout logs if include_logs = false", {
     expect_equal(status$status, scalar("COMPLETE"))
     expect_null(status$queuePosition)
     expect_equal(status$packetId, scalar(get_task_result(task_ids[[i]], q$controller)))
+    expect_equal(scalar(task_ids[[i]]), status$taskId)
     expect_null(status$logs)
   }
 })
@@ -189,6 +191,7 @@ test_that("can get status on pending report run", {
     status <- statuses[[i]]
     expect_equal(status$status, scalar("PENDING"))
     expect_equal(status$queuePosition, scalar(as.integer(i)))
+    expect_equal(scalar(task_ids[[i]]), status$taskId)
     expect_null(status$packetId)
     expect_null(status$logs)
   }

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -166,6 +166,7 @@ test_that("can get status of report run with logs", {
   expect_equal(task_times[2], dat$timeStarted)
   expect_equal(task_times[3], dat$timeComplete)
   expect_equal(get_task_logs(task_id, queue$controller), unlist(dat$logs))
+  expect_equal(task_id, dat$taskId)
 })
 
 test_that("can get status of multiple tasks without logs", {
@@ -210,6 +211,7 @@ test_that("can get status of multiple tasks without logs", {
     expect_equal(task_times[2], task_status$timeStarted)
     expect_equal(task_times[3], task_status$timeComplete)
     expect_null(task_status$logs)
+    expect_equal(task_ids[[i]], task_status$taskId)
   }
 })
 


### PR DESCRIPTION
Return taskid as part of status. This is so kotlin server can get statuses and distinguish each status by the taskId