### PR TITLE
Decouple the runner from the outpack_server store.

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -110,3 +110,15 @@ git_diff_tree <- function(left, right, repo = NULL) {
     " (?<status>[A-Z])(?<score>\\d+)?\\t(?<src>[^\\t]*)(?:\\t(?<dst>[^\\t]*))?$")
   as.data.frame(stringr::str_match(output, re)[, -1, drop = FALSE])
 }
+
+
+create_temporary_worktree <- function(repo, branch, tmpdir, env = parent.frame()) {
+  path <- withr::local_tempdir(tmpdir = tmpdir, .local_envir = env)
+
+  git_run(c("worktree", "add", path, branch), repo = repo)
+  withr::defer(env = env, {
+    git_run(c("worktree", "remove", "--force", path), repo = repo)
+  })
+
+  path
+}

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -34,18 +34,18 @@
         "GET",
         "/report/list",
         report_list,
-        porcelain::porcelain_input_query(ref = "string"),
-        porcelain::porcelain_state(root = state$root),
+        porcelain::porcelain_input_query(url = "string", ref = "string"),
+        porcelain::porcelain_state(repositories_base_path = state$repositories_base_path),
         returning = porcelain::porcelain_returning_json("report_list"),
         validate = validate)
     },
-    "GET /report/<name:string>/parameters" = function(state, validate) {
+    "GET /report/parameters" = function(state, validate) {
       porcelain::porcelain_endpoint$new(
         "GET",
-        "/report/<name:string>/parameters",
+        "/report/parameters",
         report_parameters,
-        porcelain::porcelain_input_query(ref = "string"),
-        porcelain::porcelain_state(root = state$root),
+        porcelain::porcelain_input_query(url = "string", ref = "string", name = "string"),
+        porcelain::porcelain_state(repositories_base_path = state$repositories_base_path),
         returning = porcelain::porcelain_returning_json("report_parameters"),
         validate = validate)
     },
@@ -55,7 +55,7 @@
         "/report/run",
         submit_report_run,
         porcelain::porcelain_input_body_json("data", "report_run_request"),
-        porcelain::porcelain_state(root = state$root, queue = state$queue),
+        porcelain::porcelain_state(queue = state$queue),
         returning = porcelain::porcelain_returning_json("report_run_response"),
         validate = validate)
     },

--- a/R/reports.R
+++ b/R/reports.R
@@ -41,8 +41,8 @@ get_report_parameters <- function(name, ref, root) {
 }
 
 
-get_orderly_script_path <- function(name, ref, root) {
-  contents <- gert::git_ls(root, ref = ref)
+get_orderly_script_path <- function(name, ref, repo) {
+  contents <- gert::git_ls(repo, ref = ref)
   re <- sprintf("^src/%s/(%s|orderly)\\.R$", name, name)
   matches <- grep(re, contents$path, value = TRUE, perl = TRUE)
   if (length(matches) != 1) {

--- a/R/runner.R
+++ b/R/runner.R
@@ -1,66 +1,34 @@
-runner_run <- function(orderly_root, reportname, parameters, branch, ref, ...) {
-  # Setup
-  worker_id <- Sys.getenv("RRQ_WORKER_ID")
-  worker_path <- file.path(orderly_root, ".packit", "workers", worker_id)
-  point_head_to_ref(worker_path, branch, ref)
+runner_run <- function(url, branch, ref, reportname, parameters, location, ...) {
+  storage <- Sys.getenv("ORDERLY_WORKER_STORAGE")
+  stopifnot(nzchar(storage) && fs::dir_exists(storage))
 
-  # Initial cleanup
-  git_clean(worker_path)
+  repositories <- fs::dir_create(storage, "git")
+  worktree_base <- fs::dir_create(storage, "worktrees")
 
-  # Run
-  id <- withr::with_envvar(
-    c(ORDERLY_SRC_ROOT = file.path(worker_path, "src", reportname)),
-    orderly2::orderly_run(reportname, parameters = parameters,
-                          root = orderly_root, ...)
-  )
+  repo <- git_sync(repositories, url)
 
-  # Cleanup
-  git_clean(worker_path)
+  # We could create the worktree with a detached HEAD and not bother with
+  # creating the branch, but then Orderly's metadata wouldn't be as complete.
+  #
+  # Using a named branch does introduce some persistent state in the Git
+  # repository, which the runner generally does its best to avoid. That is an
+  # acceptable compromise given that repositories are private to each worker.
+  #
+  # The branch/ref association here does not have to match the remote: if
+  # the upstream repository has just been pushed to, the commit associated with
+  # this run may be an older commit of that branch. We will happily use that
+  # older commit.
+  gert::git_branch_create(branch, ref = ref, force = TRUE, checkout = FALSE,
+                          repo = repo)
+  worktree <- create_temporary_worktree(repo, branch, worktree_base)
 
+  orderly2::orderly_init(worktree)
+  orderly2::orderly_location_add("upstream", location$type, location$args,
+                                 root = worktree)
+
+  id <- orderly2::orderly_run(reportname, parameters = parameters,
+                              fetch_metadata = TRUE, allow_remote = TRUE,
+                              location = "upstream", root = worktree, ...)
+  orderly2::orderly_location_push(id, "upstream", root = worktree)
   id
-}
-
-point_head_to_ref <- function(worker_path, branch, ref) {
-  gert::git_fetch(repo = worker_path)
-  gert::git_branch_checkout(branch, repo = worker_path)
-  gert::git_reset_hard(ref, repo = worker_path)
-}
-
-add_dir_parent_if_empty <- function(files_to_delete, path) {
-  contained_files <- list.files(path, full.names = TRUE)
-  if (length(setdiff(contained_files, files_to_delete)) > 0) {
-    return(files_to_delete)
-  }
-  add_dir_parent_if_empty(c(files_to_delete, path), dirname(path))
-}
-
-get_empty_dirs <- function(worker_path) {
-  dirs <- fs::dir_ls(worker_path, recurse = TRUE, type = "directory")
-  Reduce(add_dir_parent_if_empty, c(list(character()), dirs))
-}
-
-git_clean <- function(worker_path) {
-  # gert does not have git clean but this should achieve the same thing
-  tryCatch(
-    {
-      gert::git_stash_save(
-        include_untracked = TRUE,
-        include_ignored = TRUE,
-        repo = worker_path
-      )
-      gert::git_stash_drop(repo = worker_path)
-    },
-    error = function(e) {
-      # we don't need to rethrow the error here since it doesn't break any
-      # further report runs
-      if (e$message != "cannot stash changes - there is nothing to stash.") {
-        # TODO add logger here
-        message(e$message)
-      }
-      NULL
-    }
-  )
-  # however git ignores all directories, only cares about files, so we may
-  # have empty directories left
-  unlink(get_empty_dirs(worker_path), recursive = TRUE)
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,10 +9,6 @@ COPY . /src
 RUN Rscript -e "pak::local_install('/src')"
 
 COPY docker/bin /usr/local/bin/
- 
-RUN git config --global --add safe.directory "*"
-RUN echo ".packit" > /.gitignore
-RUN git config --global core.excludesFile "/.gitignore"
 
 # ENTRYPOINT for server is /usr/local/bin/orderly.runner.server
 # ENTRYPOINT for worker is /usr/local/bin/orderly.runner.worker

--- a/inst/schema/report_run_request.json
+++ b/inst/schema/report_run_request.json
@@ -2,13 +2,16 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
-        "name": {
+        "url": {
             "type": "string"
         },
         "branch": {
             "type": "string"
         },
         "hash": {
+            "type": "string"
+        },
+        "name": {
             "type": "string"
         },
         "parameters": {
@@ -22,8 +25,19 @@
                     }
                 }
             ]
+        },
+        "location": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "object"
+                }
+            }
         }
     },
-    "required": ["name", "branch", "hash", "parameters"],
+    "required": ["url", "branch", "hash", "name", "parameters", "location"],
     "additionalProperties": false
 }

--- a/man/Queue.Rd
+++ b/man/Queue.Rd
@@ -12,10 +12,6 @@ Object for managing running jobs on the redis queue
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
-\item{\code{root}}{Orderly root}
-
-\item{\code{config}}{Orderly config}
-
 \item{\code{controller}}{RRQ controller}
 }
 \if{html}{\out{</div>}}
@@ -35,14 +31,12 @@ Object for managing running jobs on the redis queue
 \subsection{Method \code{new()}}{
 Create object, read configuration and setup Redis connection.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Queue$new(root, queue_id = NULL, logs_dir = "logs/worker")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Queue$new(queue_id = NULL, logs_dir = "logs/worker")}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{root}}{Orderly root.}
-
 \item{\code{queue_id}}{ID of an existing queue to connect to, creates a new one
 if NULL (default NULL)}
 
@@ -57,21 +51,24 @@ if NULL (default NULL)}
 \subsection{Method \code{submit()}}{
 Submit a job the Redis queue for runner to run.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Queue$submit(reportname, parameters = NULL, branch = "master", ref = "HEAD")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Queue$submit(url, branch, ref, reportname, parameters, location)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{url}}{The URL of the Git repository containing the reports.}
+
+\item{\code{branch}}{Name of git branch to checkout the repository.}
+
+\item{\code{ref}}{Git commit-ish value (e.g HEAD or commit hash or branch name).}
+
 \item{\code{reportname}}{Name of orderly report.}
 
-\item{\code{parameters}}{Parameters to run the report with (default NULL)}
+\item{\code{parameters}}{Parameters to run the report with.}
 
-\item{\code{branch}}{Name of git branch to checkout the repository
-(default master)}
-
-\item{\code{ref}}{Git commit-ish value (e.g HEAD or commit hash or branch name).
-We reset hard to this ref and run the report. (default HEAD)}
+\item{\code{location}}{Location of the outpack repository from which to pull
+dependencies and push the produced packet.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/api.Rd
+++ b/man/api.Rd
@@ -5,7 +5,6 @@
 \title{Create orderly runner}
 \usage{
 api(
-  root,
   repositories_base_path,
   validate = NULL,
   log_level = "info",
@@ -13,8 +12,6 @@ api(
 )
 }
 \arguments{
-\item{root}{Orderly root}
-
 \item{repositories_base_path}{Path in which Git repositories are
 cloned.}
 

--- a/tests/testthat/examples/depends/depends.R
+++ b/tests/testthat/examples/depends/depends.R
@@ -1,0 +1,3 @@
+orderly2::orderly_dependency("data", "latest", files = "data.rds")
+numbers <- readRDS("data.rds")
+saveRDS(sum(numbers), "sum.rds")

--- a/tests/testthat/examples/git-clean/git-clean.R
+++ b/tests/testthat/examples/git-clean/git-clean.R
@@ -1,5 +1,0 @@
-orderly2::orderly_artefact(description = "Some data", "data.rds")
-d <- data.frame(a = 1:10, x = runif(10), y = 1:10 + runif(10))
-write.table("test", file = file.path("..", "..", "inside_draft.txt"))
-write.table("test", file = file.path("..", "..", "..", "outside_draft.txt"))
-saveRDS(d, "data.rds")

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,40 +1,35 @@
 test_that("Can parse arguments (server)", {
-  expect_mapequal(parse_main(c("path", "repos")),
+  expect_mapequal(parse_main(c("path")),
                   list(log_level = "info",
                        validate = FALSE,
                        port = 8001,
                        host = "0.0.0.0",
-                       path = "path",
-                       repositories = "repos"))
-  expect_mapequal(parse_main(c("--port=8080", "path", "repos")),
+                       repositories = "path"))
+  expect_mapequal(parse_main(c("--port=8080", "path")),
                   list(log_level = "info",
                        validate = FALSE,
                        port = 8080,
                        host = "0.0.0.0",
-                       path = "path",
-                       repositories = "repos"))
-  expect_mapequal(parse_main(c("--port=8080", "--validate", "path", "repos")),
+                       repositories = "path"))
+  expect_mapequal(parse_main(c("--port=8080", "--validate", "path")),
                   list(log_level = "info",
                        validate = TRUE,
                        port = 8080,
                        host = "0.0.0.0",
-                       path = "path",
-                       repositories = "repos"))
-  expect_mapequal(parse_main(c("--log-level=debug", "--validate", "path", "repos")),
+                       repositories = "path"))
+  expect_mapequal(parse_main(c("--log-level=debug", "--validate", "path")),
                   list(log_level = "debug",
                        validate = TRUE,
                        port = 8001,
                        host = "0.0.0.0",
-                       path = "path",
-                       repositories = "repos"))
+                       repositories = "path"))
   expect_mapequal(
-    parse_main(c("--host=host", "--log-level=debug", "--validate", "path", "repos")),
+    parse_main(c("--host=host", "--log-level=debug", "--validate", "path")),
     list(log_level = "debug",
          validate = TRUE,
          port = 8001,
          host = "host",
-         path = "path",
-         repositories = "repos")
+         repositories = "path")
   )
 })
 
@@ -44,11 +39,11 @@ test_that("Can construct api", {
   mock_run <- mockery::mock()
   mock_api <- mockery::mock(list(run = mock_run))
   mockery::stub(main, "api", mock_api)
-  main(c("--host=my-host", "--log-level=debug", "path", "repositories"))
+  main(c("--host=my-host", "--log-level=debug", "path"))
 
   mockery::expect_called(mock_api, 1)
   expect_equal(mockery::mock_args(mock_api)[[1]],
-               list("path", "repositories", FALSE, "debug"))
+               list("path", FALSE, "debug"))
 
   mockery::expect_called(mock_run, 1)
   expect_equal(mockery::mock_args(mock_run)[[1]],
@@ -56,53 +51,5 @@ test_that("Can construct api", {
 })
 
 test_that("Can parse arguments (worker)", {
-  expect_mapequal(parse_main_worker("path"),
-                  list(path = "path"))
-})
-
-test_that("Can spawn workers", {
-  skip_if_not_installed("mockery")
-
-  mock_queue_new <- mockery::mock(
-    list(controller = list(
-      queue_id = "test_queue_id",
-      con = "test_con"
-    ))
-  )
-  mockery::stub(main_worker, "Queue$new", mock_queue_new)
-
-  mock_loop <- mockery::mock()
-  mock_rrq_worker_new <- mockery::mock(
-    list(loop = mock_loop, id = "test_worker_id")
-  )
-  mockery::stub(main_worker, "rrq::rrq_worker$new", mock_rrq_worker_new)
-
-  mock_dir_create <- mockery::mock()
-  mockery::stub(main_worker, "fs::dir_create", mock_dir_create)
-
-  mock_git_clone <- mockery::mock()
-  mockery::stub(main_worker, "gert::git_clone", mock_git_clone)
-
-  main_worker(c("path"))
-
-  mockery::expect_called(mock_queue_new, 1)
-  expect_equal(mockery::mock_args(mock_queue_new)[[1]],
-               list("path"))
-
-  mockery::expect_called(mock_rrq_worker_new, 1)
-  expect_equal(mockery::mock_args(mock_rrq_worker_new)[[1]],
-               list("test_queue_id", con = "test_con"))
-
-  expected_worker_path <- file.path(
-    "path", ".packit", "workers", "test_worker_id"
-  )
-  mockery::expect_called(mock_dir_create, 1)
-  expect_equal(mockery::mock_args(mock_dir_create)[[1]],
-               list(expected_worker_path))
-
-  mockery::expect_called(mock_git_clone, 1)
-  expect_equal(mockery::mock_args(mock_git_clone)[[1]],
-               list("path", path = expected_worker_path))
-
-  mockery::expect_called(mock_loop, 1)
+  expect_mapequal(parse_main_worker("path"), list(path = "path"))
 })

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -1,50 +1,34 @@
 test_that("Can bring up queue", {
   skip_if_no_redis()
 
-  root <- create_temporary_root(use_file_store = TRUE)
-  gert::git_init(root)
-  q <- new_queue_quietly(root)
-  expect_equal(q$root, root)
-  expect_equal(q$config$core$use_file_store, TRUE)
-  expect_equal(q$controller, rrq::rrq_controller(q$controller$queue_id))
+  q <- Queue$new()
 
   expect_equal(q$number_of_workers(), 0)
-  start_queue_workers_quietly(1, q$controller)
+  start_queue_workers(1, q$controller)
   expect_equal(q$number_of_workers(), 1)
 })
+
 
 test_that("creates directory for logs & adds to worker config", {
   skip_if_no_redis()
 
-  root <- create_temporary_root(use_file_store = TRUE)
-  gert::git_init(root)
   logs_dir <- tempfile()
-  q <- new_queue_quietly(root, logs_dir = logs_dir)
-  expect_true(dir.exists(logs_dir))
-  expect_equal(logs_dir, rrq::rrq_worker_config_read("localhost", controller = q$controller)$logdir)
-})
+  q <- Queue$new(logs_dir = logs_dir)
+  expect_true(fs::dir_exists(logs_dir))
 
-test_that("Errors if not git repo", {
-  root <- create_temporary_root()
-  expect_error(
-    Queue$new(root), # nolint
-    paste(
-      "Not starting server as orderly root",
-      "is not version controlled."
-    )
-  )
+  config <- rrq::rrq_worker_config_read("localhost", controller = q$controller)
+  expect_equal(logs_dir, config$logdir)
 })
 
 
 test_that("Can connect to existing queue with queue_id", {
   skip_if_no_redis()
 
-  root <- create_temporary_root()
-  gert::git_init(root)
   queue_id <- ids::random_id()
-  q1 <- new_queue_quietly(root, queue_id = queue_id)
-  start_queue_workers_quietly(1, q1$controller)
-  q2 <- new_queue_quietly(root, queue_id = queue_id)
+  q1 <- Queue$new(queue_id = queue_id)
+  start_queue_workers(1, q1$controller)
+  q2 <- Queue$new(queue_id = queue_id)
+
   expect_equal(q1$number_of_workers(), 1)
   expect_equal(q2$number_of_workers(), 1)
 })
@@ -53,13 +37,10 @@ test_that("Can connect to existing queue with queue_id", {
 test_that("Uses ORDERLY_RUNNER_QUEUE_ID if it exists", {
   skip_if_no_redis()
 
-  root <- create_temporary_root()
-  gert::git_init(root)
   id <- ids::random_id()
-  q <- withr::with_envvar(
-    c(ORDERLY_RUNNER_QUEUE_ID = id),
-    new_queue_quietly(root)
-  )
+  q <- withr::with_envvar(c(ORDERLY_RUNNER_QUEUE_ID = id), {
+    Queue$new()
+  })
   expect_equal(q$controller$queue_id, id)
 })
 
@@ -67,9 +48,7 @@ test_that("Uses ORDERLY_RUNNER_QUEUE_ID if it exists", {
 test_that("Generated namespaced id if no ids exist", {
   skip_if_no_redis()
 
-  root <- create_temporary_root()
-  gert::git_init(root)
-  q <- new_queue_quietly(root)
+  q <- Queue$new()
   expect_match(q$controller$queue_id, "orderly.runner")
 })
 
@@ -77,68 +56,56 @@ test_that("Generated namespaced id if no ids exist", {
 test_that("Can submit task", {
   skip_if_no_redis()
 
-  root <- test_prepare_orderly_example("data")
+  upstream_git <- test_prepare_orderly_example("data")
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
 
-  q <- start_queue_with_workers(root, 1)
+  q <- start_queue_with_workers(1)
 
-  task_id <- q$submit("data", branch = gert::git_branch(root))
+  sha <- gert::git_commit_id(repo = upstream_git)
+  task_id <- q$submit(
+    url = upstream_git,
+    branch = "master",
+    ref = sha,
+    reportname = "data",
+    parameters = NULL,
+    location = list(type = "path", args = list(path = upstream_outpack))
+  )
+
   expect_worker_task_complete(task_id, q$controller, 10)
-})
-
-
-test_that("Can submit 2 tasks on different branches", {
-  skip_if_no_redis()
-
-  root <- test_prepare_orderly_example("data")
-
-  gert::git_branch_create("branch", repo = root)
-  gert::git_branch_checkout("branch", repo = root)
-  create_new_commit(root, new_file = "test.txt", add = "test.txt")
-
-  q <- start_queue_with_workers(root, 2)
-
-  task_id1 <- q$submit("data", branch = "master")
-  task_id2 <- q$submit("data", branch = "branch")
-  expect_worker_task_complete(task_id1, q$controller, 10)
-  expect_worker_task_complete(task_id2, q$controller, 10)
-
-  worker_id2 <- rrq::rrq_task_info(task_id2, controller = q$controller)$worker
-  worker2_txt <- file.path(root, ".packit", "workers", worker_id2, "test.txt")
-  expect_equal(file.exists(worker2_txt), TRUE)
-})
-
-
-test_that("Can submit 2 tasks on different commit hashes", {
-  skip_if_no_redis()
-
-  root <- test_prepare_orderly_example("data")
-  commit1 <- gert::git_commit_id(repo = root)
-  commit2 <- create_new_commit(root, new_file = "test.txt", add = "test.txt")
-
-  q <- start_queue_with_workers(root, 2)
-
-  task_id1 <- q$submit("data", ref = commit1, branch = gert::git_branch(root))
-  task_id2 <- q$submit("data", ref = commit2, branch = gert::git_branch(root))
-  expect_worker_task_complete(task_id1, q$controller, 10)
-  expect_worker_task_complete(task_id2, q$controller, 10)
-
-  worker_id2 <- rrq::rrq_task_info(task_id2, controller = q$controller)$worker
-  worker2_txt <- file.path(root, ".packit", "workers", worker_id2, "test.txt")
-  expect_equal(file.exists(worker2_txt), TRUE)
 })
 
 
 test_that("can get statuses on complete report runs with logs", {
   skip_if_no_redis()
-  root <- test_prepare_orderly_example("data")
-  q <- start_queue_with_workers(root, 1)
-  task_id1 <- q$submit("data", branch = gert::git_branch(root))
-  task_id2 <- q$submit("data", branch = gert::git_branch(root))
+
+  upstream_git <- test_prepare_orderly_example("data")
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
+
+  q <- start_queue_with_workers(1)
+
+  sha <- gert::git_commit_id(repo = upstream_git)
+  location <- list(type = "path", args = list(path = upstream_outpack))
+  task_id1 <- q$submit(
+    url = upstream_git,
+    branch = "master",
+    ref = sha,
+    reportname = "data",
+    parameters = NULL,
+    location = location
+  )
+  task_id2 <- q$submit(
+    url = upstream_git,
+    branch = "master",
+    ref = sha,
+    reportname = "data",
+    parameters = NULL,
+    location = location
+  )
+
   task_ids <- c(task_id1, task_id2)
   wait_for_task_complete(task_ids, q$controller, 5)
 
   statuses <- q$get_status(task_ids)
-
   for (i in seq_along(task_ids)) {
     status <- statuses[[i]]
     expect_equal(status$status, scalar("COMPLETE"))
@@ -147,20 +114,8 @@ test_that("can get statuses on complete report runs with logs", {
     expect_equal(status$logs, get_task_logs(task_ids[[i]], q$controller))
     expect_equal(scalar(task_ids[[i]]), status$taskId)
   }
-})
 
-test_that("can get statuses wihtout logs if include_logs = false", {
-  # run 2 reports
-  skip_if_no_redis()
-  root <- test_prepare_orderly_example("data")
-  q <- start_queue_with_workers(root, 1)
-  task_id1 <- q$submit("data", branch = gert::git_branch(root))
-  task_id2 <- q$submit("data", branch = gert::git_branch(root))
-  task_ids <- c(task_id1, task_id2)
-  wait_for_task_complete(task_ids, q$controller, 5)
-
-  statuses <- q$get_status(task_ids, FALSE)
-
+  statuses <- q$get_status(task_ids, include_logs = FALSE)
   for (i in seq_along(task_ids)) {
     status <- statuses[[i]]
     expect_equal(status$status, scalar("COMPLETE"))
@@ -171,15 +126,35 @@ test_that("can get statuses wihtout logs if include_logs = false", {
   }
 })
 
-test_that("can get status on pending report run", {
-  # run 2 reports
-  skip_if_no_redis()
-  root <- test_prepare_orderly_example("data")
-  q <- new_queue_quietly(root)
-  task_id1 <- q$submit("data", branch = gert::git_branch(root))
-  task_id2 <- q$submit("data", branch = gert::git_branch(root))
-  task_ids <- c(task_id1, task_id2)
 
+test_that("can get status on pending report run", {
+  skip_if_no_redis()
+
+  upstream_git <- test_prepare_orderly_example("data")
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
+
+  q <- start_queue()
+
+  sha <- gert::git_commit_id(repo = upstream_git)
+  location <- list(type = "path", args = list(path = upstream_outpack))
+  task_id1 <- q$submit(
+    url = upstream_git,
+    branch = "master",
+    ref = sha,
+    reportname = "data",
+    parameters = NULL,
+    location = location
+  )
+  task_id2 <- q$submit(
+    url = upstream_git,
+    branch = "master",
+    ref = sha,
+    reportname = "data",
+    parameters = NULL,
+    location = location
+  )
+
+  task_ids <- c(task_id1, task_id2)
   statuses <- q$get_status(task_ids)
 
   for (i in seq_along(task_ids)) {

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -76,8 +76,7 @@ test_that("runner cleans up after itself", {
 
   # The only things left in the storage after running should be the local clone
   # of the repository. The worktrees directory should be cleaned up and removed.
-  expect_setequal(fs::dir_ls(storage),
-                  file.path(storage, c("git", "worktrees")))
+  expect_setequal(withr::with_dir(storage, fs::dir_ls()), c("git", "worktrees"))
   expect_length(fs::dir_ls(file.path(storage, "git")), 1)
   expect_length(fs::dir_ls(file.path(storage, "worktrees")), 0)
 })

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -1,64 +1,170 @@
 test_that("runner runs as expected", {
-  orderly_root <- test_prepare_orderly_example("data")
+  upstream_git <- test_prepare_orderly_example("data")
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
 
-  worker_id <- ids::adjective_animal()
-  make_worker_dirs(orderly_root, worker_id)
-  worker_root <- file.path(orderly_root, ".packit", "workers", worker_id)
+  storage <- withr::local_tempdir()
 
-  suppressMessages(withr::with_envvar(
-    c(RRQ_WORKER_ID = worker_id),
-    runner_run(orderly_root, "data", NULL,
-               gert::git_branch(orderly_root),
-               "HEAD", echo = FALSE)
-  ))
+  expect_false(fs::dir_exists(file.path(upstream_outpack, "archive")))
 
-  # report has been run with data in archive
-  expect_equal(length(list.files(file.path(orderly_root, "archive"))), 1)
-  # cleanup has deleted draft folder
-  expect_equal(file.exists(file.path(worker_root, "draft")), FALSE)
+  sha <- gert::git_commit_id(repo = upstream_git)
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage), suppressMessages({
+    id <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = sha,
+      reportname = "data",
+      parameters = NULL,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
+
+  # Runner has pushed the result to the upstream store
+  expect_true(fs::dir_exists(
+    file.path(upstream_outpack, "archive", "data", id)))
+
+  info <- orderly2::orderly_metadata(id, root = upstream_outpack)$git
+  expect_equal(info$branch, "master")
+  expect_equal(info$sha, sha)
 })
+
 
 test_that("runner runs as expected with parameters", {
-  orderly_root <- test_prepare_orderly_example("parameters")
+  upstream_git <- test_prepare_orderly_example("parameters")
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
 
-  worker_id <- ids::adjective_animal()
-  make_worker_dirs(orderly_root, worker_id)
-  worker_root <- file.path(orderly_root, ".packit", "workers", worker_id)
+  storage <- withr::local_tempdir()
+
+  expect_false(fs::dir_exists(file.path(upstream_outpack, "archive")))
 
   parameters <- list(a = -1, b = -2, c = -3)
-  suppressMessages(withr::with_envvar(
-    c(RRQ_WORKER_ID = worker_id),
-    runner_run(orderly_root, "parameters", parameters,
-               gert::git_branch(orderly_root),
-               "HEAD", echo = FALSE)
-  ))
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage), suppressMessages({
+    id <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = gert::git_commit_id(repo = upstream_git),
+      reportname = "parameters",
+      parameters = parameters,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
 
-  report_archive <- file.path(orderly_root, "archive", "parameters")
-  rds_path <- file.path(report_archive, list.files(report_archive), "data.rds")
-  output <- readRDS(rds_path)
+  report <- file.path(upstream_outpack, "archive", "parameters", id)
+  output <- readRDS(file.path(report, "data.rds"))
 
   expect_equal(output, parameters)
-  expect_equal(file.exists(file.path(worker_root, "draft")), FALSE)
 })
 
-test_that("git clean clears unnecessary files", {
-  # git-clean.R spawns a file in draft folder and one in worker root folder
-  # and there will also be an empty folder draft/git-clean so we test
-  # all components of git_clean
-  orderly_root <- test_prepare_orderly_example("git-clean")
 
-  worker_id <- ids::adjective_animal()
-  make_worker_dirs(orderly_root, worker_id)
-  worker_root <- file.path(orderly_root, ".packit", "workers", worker_id)
+test_that("runner cleans up after itself", {
+  upstream_git <- test_prepare_orderly_example("data")
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
 
-  suppressMessages(withr::with_envvar(
-    c(RRQ_WORKER_ID = worker_id),
-    runner_run(orderly_root, "git-clean", NULL,
-               gert::git_branch(orderly_root),
-               "HEAD", echo = FALSE)
-  ))
+  storage <- withr::local_tempdir()
 
-  expect_equal(length(list.files(file.path(orderly_root, "archive"))), 1)
-  expect_equal(file.exists(file.path(worker_root, "draft")), FALSE)
-  expect_equal(file.exists(file.path(worker_root, "outside_draft.txt")), FALSE)
+  expect_false(fs::dir_exists(file.path(upstream_outpack, "archive")))
+
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage), suppressMessages({
+    id <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = gert::git_commit_id(repo = upstream_git),
+      reportname = "data",
+      parameters = NULL,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
+
+  # The only things left in the storage after running should be the local clone
+  # of the repository. The worktrees directory should be cleaned up and removed.
+  expect_setequal(fs::dir_ls(storage),
+                  file.path(storage, c("git", "worktrees")))
+  expect_length(fs::dir_ls(file.path(storage, "git")), 1)
+  expect_length(fs::dir_ls(file.path(storage, "worktrees")), 0)
+})
+
+
+test_that("runner can use an old commit", {
+  upstream_git <- test_prepare_orderly_example("data")
+  commit1 <- gert::git_commit_id(repo = upstream_git)
+  commit2 <- create_new_commit(upstream_git)
+
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
+
+  storage <- withr::local_tempdir()
+
+  expect_false(fs::dir_exists(file.path(upstream_outpack, "archive")))
+
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage), suppressMessages({
+    id1 <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = commit1,
+      reportname = "data",
+      parameters = NULL,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage), suppressMessages({
+    id2 <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = commit2,
+      reportname = "data",
+      parameters = NULL,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
+
+  info1 <- orderly2::orderly_metadata(id1, root = upstream_outpack)$git
+  expect_equal(info1$branch, "master")
+  expect_equal(info1$sha, commit1)
+
+  info2 <- orderly2::orderly_metadata(id2, root = upstream_outpack)$git
+  expect_equal(info2$branch, "master")
+  expect_equal(info2$sha, commit2)
+})
+
+
+test_that("runner can pull dependencies", {
+  upstream_git <- test_prepare_orderly_example(c("data", "depends"))
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
+
+  sha <- gert::git_commit_id(repo = upstream_git)
+
+  # We use two separate storage directories to make sure we aren't just reusing
+  # the local packet somehow.
+  storage1 <- withr::local_tempdir()
+  storage2 <- withr::local_tempdir()
+
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage1), suppressMessages({
+    id1 <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = sha,
+      reportname = "data",
+      parameters = NULL,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
+
+  withr::with_envvar(c(ORDERLY_WORKER_STORAGE = storage2), suppressMessages({
+    id2 <- runner_run(
+      url = upstream_git,
+      branch = "master",
+      ref = sha,
+      reportname = "depends",
+      parameters = NULL,
+      location = list(type = "path", args = list(path = upstream_outpack)),
+      echo = FALSE)
+  }))
+
+  # Runner has pushed the result to the upstream store
+  expect_true(fs::dir_exists(
+    file.path(upstream_outpack, "archive", "data", id1)))
+  expect_true(fs::dir_exists(
+    file.path(upstream_outpack, "archive", "depends", id2)))
+
+  info <- orderly2::orderly_metadata(id2, root = upstream_outpack)$depends
+  expect_equal(info[1,]$packet, id1)
+  expect_equal(info[1,]$query, 'latest(name == "data")')
 })


### PR DESCRIPTION
In the previous design, outpack_server, the runner API and the workers all shared a single outpack directory, and a Git repository (mostly, the workers used a clone of the shared repository for the actual execution).

This creates a very tight and brittle coupling between all the components. It makes it impossible to deploy the different components on separate machines. It requires careful reasoning about data races and conflicts between the different bits. It prevents us from sharing worker processes across multiple Packit instances, and it prevents us from using multiple Git repositories within a single instance.

The new design completely splits up the storage.
- The API server and each worker have their own local Git clones of the repositories, that are directly pulled from the upstream (eg. GitHub).
- The API servers and workers store bare Git clones of the repositories, without any worktree. When running a report, workers create a new worktree in a temporary directory, run the report and delete the worktree. This ensures a completely clean slate every time.
- The workers use their own outpack store, that is not shared with any other process.
- The workers can pull and push packets using any protocol supported by orderly2. In practice, we will be using HTTP to interact with the outpack_server used by Packit.

Currently, the workers create a new outpack store for each run, meaning they do not cache any of the packet dependencies and need to download them from the outpack_server from scratch every time. Given that, at least for now, workers and outpack_server will be operating on the same or nearby machines, this seems like a reasonable overhead.

Ideally we would keep a per-worker cache, however we need to be careful not to mix packets between different instances. One possible approach may be to re-use the file store, but start from an empty metadata store everytime. This way large unnecessary file downloads are avoided, while preserving some degree of isolation between runs and instances.