### PR TITLE
Remove the REDIS_CONTAINER_NAME environment variable.

### DIFF
--- a/R/queue.R
+++ b/R/queue.R
@@ -93,11 +93,6 @@ Queue <- R6::R6Class("Queue", # nolint
           taskId = scalar(task_ids[index])
         )
       })
-    },
-
-    #' @description Destroy queue
-    finalize = function() {
-      rrq::rrq_destroy(controller = self$controller)
     }
   ),
 )

--- a/R/queue.R
+++ b/R/queue.R
@@ -28,14 +28,8 @@ Queue <- R6::R6Class("Queue", # nolint
         ))
       }
 
-      # Connect to Redis
-      con <- redux::hiredis(host = redis_host())
-
       # Create queue
-      self$controller <- rrq::rrq_controller(
-        queue_id %||% orderly_queue_id(),
-        con = con
-      )
+      self$controller <- rrq::rrq_controller(queue_id %||% orderly_queue_id())
       dir.create(logs_dir, showWarnings = FALSE)
       worker_config <- rrq::rrq_worker_config(heartbeat_period = 10, logdir = logs_dir)
       rrq::rrq_worker_config_save("localhost", worker_config,
@@ -115,9 +109,4 @@ runner_has_git <- function(path) {
 orderly_queue_id <- function() {
   id <- Sys.getenv("ORDERLY_RUNNER_QUEUE_ID", "")
   if (nzchar(id)) id else sprintf("orderly.runner:%s", ids::random_id())
-}
-
-redis_host <- function() {
-  name <- Sys.getenv("REDIS_CONTAINER_NAME", "")
-  if (nzchar(name)) name else NULL
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ To run the full docker setup:
 
 ## Notes for deploying
 
-When running the server or worker containers, you should have `REDIS_CONTAINER_NAME` env var set to connect to the redis container from the server and worker containers. You should also set the `ORDERLY_RUNNER_QUEUE_ID` to the same thing between server and worker containers so they connect to the same queue.
+When running the server or worker containers, you should set `REDIS_URL` to point to your Redis instance.
+You should also set the `ORDERLY_RUNNER_QUEUE_ID` to the same thing between server and worker containers so they connect to the same queue.
 
 ## License
 

--- a/docker/test/run-test
+++ b/docker/test/run-test
@@ -32,7 +32,7 @@ docker run --rm -d --pull=always \
        --name=$SERVER \
        --entrypoint="/usr/local/bin/orderly.runner.server" \
        --env=ORDERLY_RUNNER_QUEUE_ID=$ORDERLY_RUNNER_QUEUE_ID \
-       --env=REDIS_CONTAINER_NAME=$REDIS \
+       --env=REDIS_URL=redis://$REDIS \
        -p 127.0.0.1:8001:8001 \
        -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
        -v $ORDERLY_LOGS_VOLUME:$LOGS_DIR \
@@ -44,7 +44,7 @@ docker run --rm -d --pull=always \
        --name=$WORKER \
        --entrypoint="/usr/local/bin/orderly.runner.worker" \
        --env=ORDERLY_RUNNER_QUEUE_ID=$ORDERLY_RUNNER_QUEUE_ID \
-       --env=REDIS_CONTAINER_NAME=$REDIS \
+       --env=REDIS_URL=redis://$REDIS \
        -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
        -v $ORDERLY_LOGS_VOLUME:$LOGS_DIR \
        $ORDERLY_RUNNER_IMAGE \

--- a/man/Queue.Rd
+++ b/man/Queue.Rd
@@ -27,7 +27,6 @@ Object for managing running jobs on the redis queue
 \item \href{#method-Queue-submit}{\code{Queue$submit()}}
 \item \href{#method-Queue-number_of_workers}{\code{Queue$number_of_workers()}}
 \item \href{#method-Queue-get_status}{\code{Queue$get_status()}}
-\item \href{#method-Queue-finalize}{\code{Queue$finalize()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -107,15 +106,5 @@ Gets status of packet run
 \subsection{Returns}{
 status of redis queue job
 }
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Queue-finalize"></a>}}
-\if{latex}{\out{\hypertarget{method-Queue-finalize}{}}}
-\subsection{Method \code{finalize()}}{
-Destroy queue
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Queue$finalize()}\if{html}{\out{</div>}}
-}
-
 }
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -90,7 +90,7 @@ test_that("can get parameters for a report", {
 test_that("can run orderly reports", {
   skip_if_no_redis()
 
-  queue_id <- "orderly.runner:cute-animal"
+  queue_id <- orderly_queue_id()
   repo <- test_prepare_orderly_example(c("data", "parameters"))
   gert::git_init(repo)
   orderly2::orderly_gitignore_update("(root)", root = repo)
@@ -138,7 +138,7 @@ test_that("can run orderly reports", {
 test_that("can get statuses of jobs", {
   # run 2 jobs first and wait for finish
   skip_if_no_redis()
-  queue_id <- "orderly.runner:bad-animal"
+  queue_id <- orderly_queue_id()
   repo <- test_prepare_orderly_example(c("data", "parameters"))
   gert::git_init(repo)
   orderly2::orderly_gitignore_update("(root)", root = repo)

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -196,13 +196,3 @@ test_that("can get status on pending report run", {
     expect_null(status$logs)
   }
 })
-test_that("redis_host uses REDIS_CONTAINER_NAME if it exists", {
-  root <- create_temporary_root()
-  gert::git_init(root)
-  id <- ids::random_id()
-  redis_host_name <- withr::with_envvar(
-    c(REDIS_CONTAINER_NAME = id),
-    redis_host()
-  )
-  expect_equal(redis_host_name, id)
-})


### PR DESCRIPTION
rrq already respects the REDIS_URL if no host is given. That is more general than just a container name, since it could be running on a different port / outside of Docker / over TLS / require a password.