### PR TITLE
Use entire api object in API tests.

### DIFF
--- a/tests/testthat/helper-orderly-runner.R
+++ b/tests/testthat/helper-orderly-runner.R
@@ -1,22 +1,19 @@
-orderly_runner_endpoint <- function(
-  method, path,
-  root = NULL,
-  repositories = NULL,
-  validate = TRUE,
-  skip_queue_creation = FALSE
-) {
-  if (skip_queue_creation) {
-    queue <- NULL
-  } else {
-    queue <- Queue$new(root)
+create_api <- function(root = NULL,
+                       repositories = NULL,
+                       log_level = "off",
+                       ...,
+                       .local_envir = parent.frame()) {
+  if (is.null(repositories)) {
+    repositories <- withr::local_tempdir()
   }
-  porcelain::porcelain_package_endpoint(
-    "orderly.runner", method, path,
-    state = list(root = root,
-                 repositories_base_path = repositories,
-                 queue = queue),
-    validate = validate
-  )
+
+  api(root, repositories, validate = TRUE, log_level = log_level, ...)
+}
+
+
+expect_success <- function(res) {
+  expect_equal(res$status, 200)
+  invisible(jsonlite::fromJSON(res$body)$data)
 }
 
 

--- a/tests/testthat/helper-orderly-runner.R
+++ b/tests/testthat/helper-orderly-runner.R
@@ -2,9 +2,9 @@ create_api <- function(root = NULL,
                        repositories = NULL,
                        log_level = "off",
                        ...,
-                       .local_envir = parent.frame()) {
+                       env = parent.frame()) {
   if (is.null(repositories)) {
-    repositories <- withr::local_tempdir()
+    repositories <- withr::local_tempdir(.local_envir = env)
   }
 
   api(root, repositories, validate = TRUE, log_level = log_level, ...)

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -59,6 +59,7 @@ test_that("can list branches in repository", {
   # branches:
   res <- obj$request("POST", "/repository/fetch",
                      body = jsonlite::toJSON(list(url = scalar(upstream))))
+  print(res)
   data <- expect_success(res)
 
   res <- obj$request("GET", "/repository/branches",

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -59,7 +59,6 @@ test_that("can list branches in repository", {
   # branches:
   res <- obj$request("POST", "/repository/fetch",
                      body = jsonlite::toJSON(list(url = scalar(upstream))))
-  print(res)
   data <- expect_success(res)
 
   res <- obj$request("GET", "/repository/branches",


### PR DESCRIPTION
The API tests used to setup individual endpoints to run the tests. That is a bit verbose and duplicates a bunch of code from the `api.R` file.

This will be made much worse when we introduce `url` parameters to all the endpoints, since all the tests will need to make a API call to fetch the repository first, which will lead to more boilerplate.

Using the api object solves this issue.