### PR TITLE
Include R errors in the log files.

### DIFF
--- a/R/runner.R
+++ b/R/runner.R
@@ -1,4 +1,4 @@
-runner_run <- function(url, branch, ref, reportname, parameters, location, ssh_key = NULL, ...) {
+runner_run_internal <- function(url, branch, ref, reportname, parameters, location, ssh_key = NULL, ...) {
   storage <- Sys.getenv("ORDERLY_WORKER_STORAGE")
   stopifnot(nzchar(storage) && fs::dir_exists(storage))
 
@@ -31,4 +31,15 @@ runner_run <- function(url, branch, ref, reportname, parameters, location, ssh_k
                               location = "upstream", root = worktree, ...)
   orderly2::orderly_location_push(id, "upstream", root = worktree)
   id
+}
+
+# This is a simple wrapper that prints any error that gets thrown.
+# The error is re-thrown after it is logged to ensure the task still fails.
+runner_run <- function(...) {
+  tryCatch(
+    runner_run_internal(...),
+    error = function(e) {
+      print(e)
+      stop(e)
+    })
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -372,3 +372,56 @@ test_that("can get statuses of jobs", {
     expect_equal(task_ids[[i]], task_status$taskId)
   }
 })
+
+
+test_that("errors are included in task logs", {
+  skip_if_no_redis()
+  queue_id <- orderly_queue_id()
+  controller <- rrq::rrq_controller(queue_id)
+
+  obj <- withr::with_envvar(
+    c(ORDERLY_RUNNER_QUEUE_ID = queue_id),
+    create_api())
+
+  start_queue_workers(1, controller)
+
+  upstream_git <- test_prepare_orderly_example("data")
+  writeLines("stop('Oh no!')",
+             file.path(upstream_git, "src", "data", "data.R"))
+  git_add_and_commit(upstream_git)
+
+  upstream_outpack <- create_temporary_root(use_file_store = TRUE)
+
+  req <- list(
+    name = scalar("data"),
+    branch = scalar(gert::git_branch(repo = upstream_git)),
+    hash = scalar(gert::git_commit_id(repo = upstream_git)),
+    parameters = scalar(NULL),
+    location = list(
+      type = scalar("path"),
+      args = list(
+        path = scalar(upstream_outpack)
+      )
+    )
+  )
+
+  res <- obj$request("POST",
+                     "/report/run",
+                     query = list(url = upstream_git),
+                     body = jsonlite::toJSON(req))
+  dat <- expect_success(res)
+
+  rrq::rrq_task_wait(dat$taskId, controller = controller)
+
+  res <- obj$request("POST", "/report/status",
+                     body = jsonlite::toJSON(dat$taskId),
+                     query = list(include_logs = TRUE))
+  dat <- expect_success(res)
+  status <- dat[1,]
+
+  expect_equal(status$status, "ERROR")
+  expect_contains(unlist(status$logs),
+                  c("! Failed to run report",
+                    "Caused by error:",
+                    "! Oh no!"))
+})


### PR DESCRIPTION
Currently, when an R error is thrown by a report, it is caught by the rrq worker and is stored in Redis, but it is not exposed over the runner API anywhere.

Rather than introduce yet another field in API, we print the error from the worker process, which will make it visible at the end of the tasks log file.