### PR TITLE
Add support for a library mounted at /library

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,10 @@ RUN Rscript -e "pak::local_install_deps('/src')"
 COPY . /src
 RUN Rscript -e "pak::local_install('/src')"
 
+VOLUME /library
+
+ENV R_LIBS=/library:/usr/local/lib/R/site-library:/usr/local/lib/R/library
+
 COPY docker/bin /usr/local/bin/
 
 # ENTRYPOINT for server is /usr/local/bin/orderly.runner.server


### PR DESCRIPTION
this is just a dockerfile configuration at this point, and will do nothing most of the time.  However, we can use this to mount in a common library at `/library` which will be used in preference to things installed into the image itself. I've had to do this via `R_LIBS` and not the more usual `R_LIBS_USER` because at least in an image the library specified by `R_LIBS_USER` gets put last in the search path, possibly because the image runs as root?