### PR TITLE
Enable non-pinned CRAN

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          pull: true
           push: true
           file: ./docker/Dockerfile
           tags: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.runner
 Title: Run an 'orderly2' Packet
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.4
+FROM rocker/r-ver:4
 
 RUN install2.r pak
 


### PR DESCRIPTION
```
$ docker run --rm mrcide/orderly.runner:mrc-6526 Rscript -e 'getOption("repos")'
                                         CRAN 
"https://p3m.dev/cran/__linux__/noble/latest" 
```

Compare with main:

```
 docker run --rm mrcide/orderly.runner:main Rscript -e 'getOption("repos")'
                                             CRAN 
"https://p3m.dev/cran/__linux__/noble/2025-04-10" 
```

This is annoying to debug, and is disabled in the most recent (R) versions built in the base container