### PR TITLE
Add more libraries to the base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,11 @@
 FROM rocker/r-ver:4
 
+RUN apt-get update && apt-get install -y --no-install-recommends
+    libpq5 \
+    libproj25 \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN install2.r pak
 
 COPY DESCRIPTION /src/DESCRIPTION

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocker/r-ver:4
 
-RUN apt-get update && apt-get install -y --no-install-recommends
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     libproj25 \
     pandoc \


### PR DESCRIPTION
These are not really needed for the runner pandoc in particular is quite useful. The others are required to be able to load the `RPostgres` and `ggalt` packages that vimc use