### PR TITLE
Add support for cancelling a task

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.runner
 Title: Run an 'orderly2' Packet
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -38,5 +38,4 @@ Config/testthat/edition: 3
 Remotes:
     mrc-ide/orderly2,
     reside-ic/porcelain,
-    mrc-ide/rrq,
-    r-lib/gert
+    mrc-ide/rrq

--- a/R/api.R
+++ b/R/api.R
@@ -150,3 +150,12 @@ report_run_status <- function(queue, include_logs, data) {
   task_ids <- jsonlite::fromJSON(data)
   queue$get_status(task_ids, include_logs)
 }
+
+##' @porcelain
+##'   POST /report/cancel => json(report_run_cancel_response)
+##'   state queue :: queue
+##'   body data :: json(report_run_cancel_request)
+report_run_cancel <- function(queue, data) {
+  task_id <- jsonlite::fromJSON(data)
+  queue$cancel(task_id)
+}

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -71,5 +71,15 @@
         porcelain::porcelain_state(queue = state$queue),
         returning = porcelain::porcelain_returning_json("report_run_status_response"),
         validate = validate)
+    },
+    "POST /report/cancel" = function(state, validate) {
+      porcelain::porcelain_endpoint$new(
+        "POST",
+        "/report/cancel",
+        report_run_cancel,
+        porcelain::porcelain_input_body_json("data", "report_run_cancel_request"),
+        porcelain::porcelain_state(queue = state$queue),
+        returning = porcelain::porcelain_returning_json("report_run_cancel_response"),
+        validate = validate)
     })
 }

--- a/R/queue.R
+++ b/R/queue.R
@@ -90,7 +90,7 @@ Queue <- R6::R6Class("Queue", # nolint
     },
 
     #' @description
-    #' Gets status of packet run
+    #' Cancels a packet run
     #'
     #' @param task_id A single task to cancel
     #' @return Nothing, or error if cancellation was not possible

--- a/R/queue.R
+++ b/R/queue.R
@@ -54,7 +54,8 @@ Queue <- R6::R6Class("Queue", # nolint
       )
     },
 
-    # Just until we add queue status for testing
+    #' @description
+    #' Gets the number of workers, only implemented until we add queue status for testing
     number_of_workers = function() {
       rrq::rrq_worker_len(self$controller)
     },
@@ -86,6 +87,20 @@ Queue <- R6::R6Class("Queue", # nolint
           taskId = scalar(task_ids[index])
         )
       })
+    },
+
+    #' @description
+    #' Gets status of packet run
+    #'
+    #' @param task_id A single task to cancel
+    #' @return Nothing, or error if cancellation was not possible
+    cancel = function(task_id) {
+      tryCatch(
+        rrq::rrq_task_cancel(task_id, controller = self$controller),
+        error = function(e) {
+          porcelain::porcelain_stop(conditionMessage(e))
+        }
+      )
     }
   ),
 )

--- a/inst/schema/report_run_cancel_request.json
+++ b/inst/schema/report_run_cancel_request.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "string"
+}

--- a/inst/schema/report_run_cancel_response.json
+++ b/inst/schema/report_run_cancel_response.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "null"
+}

--- a/man/Queue.Rd
+++ b/man/Queue.Rd
@@ -23,6 +23,7 @@ Object for managing running jobs on the redis queue
 \item \href{#method-Queue-submit}{\code{Queue$submit()}}
 \item \href{#method-Queue-number_of_workers}{\code{Queue$number_of_workers()}}
 \item \href{#method-Queue-get_status}{\code{Queue$get_status()}}
+\item \href{#method-Queue-cancel}{\code{Queue$cancel()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -88,6 +89,7 @@ dependencies and push the produced packet.}
 \if{html}{\out{<a id="method-Queue-number_of_workers"></a>}}
 \if{latex}{\out{\hypertarget{method-Queue-number_of_workers}{}}}
 \subsection{Method \code{number_of_workers()}}{
+Gets the number of workers, only implemented until we add queue status for testing
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Queue$number_of_workers()}\if{html}{\out{</div>}}
 }
@@ -113,6 +115,26 @@ Gets status of packet run
 }
 \subsection{Returns}{
 status of redis queue job
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Queue-cancel"></a>}}
+\if{latex}{\out{\hypertarget{method-Queue-cancel}{}}}
+\subsection{Method \code{cancel()}}{
+Gets status of packet run
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Queue$cancel(task_id)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{task_id}}{A single task to cancel}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Nothing, or error if cancellation was not possible
 }
 }
 }

--- a/man/Queue.Rd
+++ b/man/Queue.Rd
@@ -121,7 +121,7 @@ status of redis queue job
 \if{html}{\out{<a id="method-Queue-cancel"></a>}}
 \if{latex}{\out{\hypertarget{method-Queue-cancel}{}}}
 \subsection{Method \code{cancel()}}{
-Gets status of packet run
+Cancels a packet run
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Queue$cancel(task_id)}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Adds basic support for cancelling a single task.  There's no support in rrq for cancelling a bunch at once, so I've not wired it up to support that.  Currently the response is `null` on successful cancel, error if cancellation is not possible but alternatively we could return `true`/`false` instead if that would be easier to support from packit