### PR TITLE
Mrc-6548 Get statuses returns valid ids

### DIFF
--- a/R/queue.R
+++ b/R/queue.R
@@ -91,7 +91,7 @@ Queue <- R6::R6Class("Queue", # nolint
         )
       })
 
-      list(statuses = task_statuses, missing_task_ids = missing_task_ids)
+      list(statuses = task_statuses, missingTaskIds = missing_task_ids)
     },
 
     #' @description

--- a/R/queue.R
+++ b/R/queue.R
@@ -67,27 +67,27 @@ Queue <- R6::R6Class("Queue", # nolint
     #' @param include_logs Whether to include logs in response or not
     #' @return statuses of redis queue jobs
     get_status = function(task_ids, include_logs = TRUE) {
-      valid_task_ids <- task_ids[rrq::rrq_task_exists(task_ids, controller = self$controller)]
-      invalid_task_ids <- setdiff(task_ids, valid_task_ids)
+      found_task_ids <- task_ids[rrq::rrq_task_exists(task_ids, controller = self$controller)]
+      missing_task_ids <- setdiff(task_ids, found_task_ids)
 
-      if (length(invalid_task_ids) > 0) {
-        warning(sprintf("Job ids [%s] do not exist in the queue", paste(invalid_task_ids, collapse = ", ")))
+      if (length(missing_task_ids) > 0) {
+        warning(sprintf("Job ids [%s] do not exist in the queue", paste(missing_task_ids, collapse = ", ")))
       }
 
-      statuses <- rrq::rrq_task_status(valid_task_ids, controller = self$controller)
-      tasks_times <- rrq::rrq_task_times(valid_task_ids, controller = self$controller)
-      queuePositions <- rrq::rrq_task_position(valid_task_ids, controller = self$controller)
+      statuses <- rrq::rrq_task_status(found_task_ids, controller = self$controller)
+      tasks_times <- rrq::rrq_task_times(found_task_ids, controller = self$controller)
+      queuePositions <- rrq::rrq_task_position(found_task_ids, controller = self$controller)
 
-      lapply(seq_along(valid_task_ids), function(index) {
+      lapply(seq_along(found_task_ids), function(index) {
         list(
           status = scalar(statuses[index]),
           queuePosition = if (statuses[index] == "PENDING") scalar(queuePositions[index]) else NULL,
-          timeQueued = scalar(tasks_times[valid_task_ids[index], 1]),
-          timeStarted = scalar(tasks_times[valid_task_ids[index], 2]),
-          timeComplete = scalar(tasks_times[valid_task_ids[index], 3]),
-          packetId = if (statuses[index] == "COMPLETE") scalar(rrq::rrq_task_result(valid_task_ids[index], controller = self$controller)) else NULL,
-          logs = if (include_logs) rrq::rrq_task_log(valid_task_ids[index], controller = self$controller) else NULL,
-          taskId = scalar(valid_task_ids[index])
+          timeQueued = scalar(tasks_times[found_task_ids[index], 1]),
+          timeStarted = scalar(tasks_times[found_task_ids[index], 2]),
+          timeComplete = scalar(tasks_times[found_task_ids[index], 3]),
+          packetId = if (statuses[index] == "COMPLETE") scalar(rrq::rrq_task_result(found_task_ids[index], controller = self$controller)) else NULL,
+          logs = if (include_logs) rrq::rrq_task_log(found_task_ids[index], controller = self$controller) else NULL,
+          taskId = scalar(found_task_ids[index])
         )
       })
     },

--- a/R/queue.R
+++ b/R/queue.R
@@ -61,30 +61,33 @@ Queue <- R6::R6Class("Queue", # nolint
     },
 
     #' @description
-    #' Gets status of packet run
+    #' Gets statuses of packet runs in the queue.
     #'
-    #' @param task_ids Task ids  to get status of.
+    #' @param task_ids Task ids to get status of.
     #' @param include_logs Whether to include logs in response or not
-    #' @return status of redis queue job
+    #' @return statuses of redis queue jobs
     get_status = function(task_ids, include_logs = TRUE) {
-      invalid_task_ids <- task_ids[!rrq::rrq_task_exists(task_ids, controller = self$controller)]
-      if (length(invalid_task_ids) > 0) {
-        porcelain::porcelain_stop(sprintf("Job ids [%s] do not exist in the queue", paste(invalid_task_ids, collapse = ", ")))
-      }
-      statuses <- rrq::rrq_task_status(task_ids, controller = self$controller)
-      tasks_times <- rrq::rrq_task_times(task_ids, controller = self$controller)
-      queuePositions <- rrq::rrq_task_position(task_ids, controller = self$controller)
+      valid_task_ids <- task_ids[rrq::rrq_task_exists(task_ids, controller = self$controller)]
+      invalid_task_ids <- setdiff(task_ids, valid_task_ids)
 
-      lapply(seq_along(task_ids), function(index) {
+      if (length(invalid_task_ids) > 0) {
+        sprintf("Job ids [%s] do not exist in the queue", paste(invalid_task_ids, collapse = ", "))
+      }
+
+      statuses <- rrq::rrq_task_status(valid_task_ids, controller = self$controller)
+      tasks_times <- rrq::rrq_task_times(valid_task_ids, controller = self$controller)
+      queuePositions <- rrq::rrq_task_position(valid_task_ids, controller = self$controller)
+
+      lapply(seq_along(valid_task_ids), function(index) {
         list(
           status = scalar(statuses[index]),
           queuePosition = if (statuses[index] == "PENDING") scalar(queuePositions[index]) else NULL,
-          timeQueued = scalar(tasks_times[task_ids[index], 1]),
-          timeStarted = scalar(tasks_times[task_ids[index], 2]),
-          timeComplete = scalar(tasks_times[task_ids[index], 3]),
-          packetId = if (statuses[index] == "COMPLETE") scalar(rrq::rrq_task_result(task_ids[index], controller = self$controller)) else NULL,
-          logs = if (include_logs) rrq::rrq_task_log(task_ids[index], controller = self$controller) else NULL,
-          taskId = scalar(task_ids[index])
+          timeQueued = scalar(tasks_times[valid_task_ids[index], 1]),
+          timeStarted = scalar(tasks_times[valid_task_ids[index], 2]),
+          timeComplete = scalar(tasks_times[valid_task_ids[index], 3]),
+          packetId = if (statuses[index] == "COMPLETE") scalar(rrq::rrq_task_result(valid_task_ids[index], controller = self$controller)) else NULL,
+          logs = if (include_logs) rrq::rrq_task_log(valid_task_ids[index], controller = self$controller) else NULL,
+          taskId = scalar(valid_task_ids[index])
         )
       })
     },

--- a/R/queue.R
+++ b/R/queue.R
@@ -78,7 +78,7 @@ Queue <- R6::R6Class("Queue", # nolint
       tasks_times <- rrq::rrq_task_times(found_task_ids, controller = self$controller)
       queuePositions <- rrq::rrq_task_position(found_task_ids, controller = self$controller)
 
-      lapply(seq_along(found_task_ids), function(index) {
+      task_statuses <- lapply(seq_along(found_task_ids), function(index) {
         list(
           status = scalar(statuses[index]),
           queuePosition = if (statuses[index] == "PENDING") scalar(queuePositions[index]) else NULL,
@@ -90,6 +90,8 @@ Queue <- R6::R6Class("Queue", # nolint
           taskId = scalar(found_task_ids[index])
         )
       })
+
+      list(statuses = task_statuses, missing_task_ids = missing_task_ids)
     },
 
     #' @description

--- a/R/queue.R
+++ b/R/queue.R
@@ -71,7 +71,7 @@ Queue <- R6::R6Class("Queue", # nolint
       invalid_task_ids <- setdiff(task_ids, valid_task_ids)
 
       if (length(invalid_task_ids) > 0) {
-        sprintf("Job ids [%s] do not exist in the queue", paste(invalid_task_ids, collapse = ", "))
+        warning(sprintf("Job ids [%s] do not exist in the queue", paste(invalid_task_ids, collapse = ", ")))
       }
 
       statuses <- rrq::rrq_task_status(valid_task_ids, controller = self$controller)

--- a/inst/schema/report_run_status_response.json
+++ b/inst/schema/report_run_status_response.json
@@ -43,13 +43,13 @@
                 "additionalProperties": false
             }
         },
-        "missing_task_ids": {
+        "missingTaskIds": {
             "type": "array",
             "items": {
                 "type": "string"
             }
         }
     },
-    "required": ["statuses", "missing_task_ids"],
+    "required": ["statuses", "missingTaskIds"],
     "additionalProperties": false
 }

--- a/inst/schema/report_run_status_response.json
+++ b/inst/schema/report_run_status_response.json
@@ -1,42 +1,55 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "timeQueued": {
-                "type": "number",
-                "description": "time queued in UTC time."
-            },
-            "timeStarted": {
-                "type": ["number", "null"],
-                "description": "time started run in UTC time."
-            },
-            "timeComplete": {
-                "type": ["number", "null"],
-                "description": "time completed in UTC time."
-            },
-            "queuePosition": {
-                "type": ["number", "null"]
-            },
-            "logs": {
-                "type": ["array", "null"],
-                "items": {
-                    "type": "string"
-                }
-            },
-            "status": {
-                "type": "string",
-                "enum": ["PENDING", "RUNNING","COMPLETE", "ERROR", "CANCELLED", "DIED", "TIMEOUT", "IMPOSSIBLE","DEFERRED", "MOVED"]
-            },
-            "packetId": {
-                "type": ["string", "null"]
-            },
-            "taskId": {
-              "type": "string"
+    "type": "object",
+    "properties": {
+        "statuses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "timeQueued": {
+                        "type": "number",
+                        "description": "time queued in UTC time."
+                    },
+                    "timeStarted": {
+                        "type": ["number", "null"],
+                        "description": "time started run in UTC time."
+                    },
+                    "timeComplete": {
+                        "type": ["number", "null"],
+                        "description": "time completed in UTC time."
+                    },
+                    "queuePosition": {
+                        "type": ["number", "null"]
+                    },
+                    "logs": {
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["PENDING", "RUNNING","COMPLETE", "ERROR", "CANCELLED", "DIED", "TIMEOUT", "IMPOSSIBLE","DEFERRED", "MOVED"]
+                    },
+                    "packetId": {
+                        "type": ["string", "null"]
+                    },
+                    "taskId": {
+                      "type": "string"
+                    }
+                },
+                "required": ["timeQueued", "timeStarted", "queuePosition", "logs", "status", "packetId", "taskId"],
+                "additionalProperties": false
             }
         },
-        "required": ["timeQueued", "timeStarted", "queuePosition", "logs", "status", "packetId", "taskId"],
-        "additionalProperties": false
-    }
+        "missing_task_ids": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": ["statuses", "missing_task_ids"],
+    "additionalProperties": false
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -357,10 +357,10 @@ test_that("can get statuses of jobs", {
   res <- obj$request("POST", "/report/status",
                      body = jsonlite::toJSON(task_ids),
                      query = list(include_logs = TRUE))
-  dat <- expect_success(res)
+  statuses <- expect_success(res)$statuses
 
   for (i in seq_along(task_ids)) {
-    task_status <- dat[i,]
+    task_status <- statuses[i,]
     task_times <- get_task_times(task_ids[[i]], controller)
     expect_equal(task_status$status, "COMPLETE")
     expect_true(is.na(task_status$queuePosition))
@@ -416,8 +416,8 @@ test_that("errors are included in task logs", {
   res <- obj$request("POST", "/report/status",
                      body = jsonlite::toJSON(dat$taskId),
                      query = list(include_logs = TRUE))
-  dat <- expect_success(res)
-  status <- dat[1,]
+
+  status <- expect_success(res)$statuses[1, ]
 
   expect_equal(status$status, "ERROR")
   expect_contains(unlist(status$logs),

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -197,5 +197,5 @@ test_that("only returns existent status of task_ids", {
   res <- q$get_status(task_ids, include_logs = FALSE)
 
   expect_length(res, 1)
-  expect_equal(res[[1]]$taskId, task_ids[[1]])
+  expect_equal(res[[1]]$taskId, scalar(task_ids[[1]]))
 })

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -105,7 +105,7 @@ test_that("can get statuses on complete report runs with logs", {
   task_ids <- c(task_id1, task_id2)
   wait_for_task_complete(task_ids, q$controller, 5)
 
-  statuses <- q$get_status(task_ids)
+  statuses <- q$get_status(task_ids)$statuses
   for (i in seq_along(task_ids)) {
     status <- statuses[[i]]
     expect_equal(status$status, scalar("COMPLETE"))
@@ -115,7 +115,7 @@ test_that("can get statuses on complete report runs with logs", {
     expect_equal(scalar(task_ids[[i]]), status$taskId)
   }
 
-  statuses <- q$get_status(task_ids, include_logs = FALSE)
+  statuses <- q$get_status(task_ids, include_logs = FALSE)$statuses
   for (i in seq_along(task_ids)) {
     status <- statuses[[i]]
     expect_equal(status$status, scalar("COMPLETE"))
@@ -155,7 +155,7 @@ test_that("can get status on pending report run", {
   )
 
   task_ids <- c(task_id1, task_id2)
-  statuses <- q$get_status(task_ids)
+  statuses <- q$get_status(task_ids)$statuses
 
   for (i in seq_along(task_ids)) {
     status <- statuses[[i]]
@@ -196,6 +196,8 @@ test_that("only returns existent status of task_ids", {
 
   res <- q$get_status(task_ids, include_logs = FALSE)
 
-  expect_length(res, 1)
-  expect_equal(res[[1]]$taskId, scalar(task_ids[[1]]))
+  expect_length(res$statuses, 1)
+  expect_equal(res$statuses[[1]]$taskId, scalar(task_ids[[1]]))
+  expect_length(res$missing_task_ids, 1)
+  expect_equal(res$missing_task_ids[[1]], "non-existent-id")
 })

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -198,6 +198,6 @@ test_that("only returns existent status of task_ids", {
 
   expect_length(res$statuses, 1)
   expect_equal(res$statuses[[1]]$taskId, scalar(task_ids[[1]]))
-  expect_length(res$missing_task_ids, 1)
-  expect_equal(res$missing_task_ids[[1]], "non-existent-id")
+  expect_length(res$missingTaskIds, 1)
+  expect_equal(res$missingTaskIds[[1]], "non-existent-id")
 })

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -289,6 +289,6 @@ test_that("returns statuses for only existent task ids", {
 
   expect_length(dat$statuses, 1)
   expect_equal(dat$statuses[[1]]$taskId, task_ids[[1]])
-  expect_length(dat$missing_task_ids, 1)
-  expect_equal(dat$missing_task_ids[[1]], "non-existent-id")
+  expect_length(dat$missingTaskIds, 1)
+  expect_equal(dat$missingTaskIds[[1]], "non-existent-id")
 })

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -273,7 +273,7 @@ test_that("returns statuses for only existent task ids", {
     httr::content_type("application/json")
   )
   expect_equal(httr::status_code(r1), 200)
-  task_ids <- c("httr::content(r1)$data$taskId", "non-existant-id")
+  task_ids <- c(httr::content(r1)$data$taskId, "non-existent-id")
   
   res <- bg$request(
     "POST",

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -184,7 +184,8 @@ test_that("can get status of report run with logs", {
     encode = "raw",
     httr::content_type("application/json")
   )
-  dat <- httr::content(res)$data[[1]]
+
+  dat <- httr::content(res)$data$statuses[[1]]
   task_times <- get_task_times(task_id, queue$controller)
   expect_equal(httr::status_code(res), 200)
   expect_equal(dat$status, "COMPLETE")

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -237,7 +237,7 @@ test_that("can get status of multiple tasks without logs", {
     encode = "raw",
     httr::content_type("application/json")
   )
-  dat <- httr::content(res)$data
+  dat <- httr::content(res)$data$statuses
 
   for (i in seq_along(task_ids)) {
     task_status <- dat[[i]]
@@ -274,7 +274,7 @@ test_that("returns statuses for only existent task ids", {
   )
   expect_equal(httr::status_code(r1), 200)
   task_ids <- c(httr::content(r1)$data$taskId, "non-existent-id")
-  
+
   res <- bg$request(
     "POST",
     "/report/status",
@@ -283,9 +283,12 @@ test_that("returns statuses for only existent task ids", {
     encode = "raw",
     httr::content_type("application/json")
   )
-  
+
   expect_equal(httr::status_code(res), 200)
   dat <- httr::content(res)$data
-  expect_length(dat, 1)
-  expect_equal(dat[[1]]$taskId, task_ids[[1]])
+
+  expect_length(dat$statuses, 1)
+  expect_equal(dat$statuses[[1]]$taskId, task_ids[[1]])
+  expect_length(dat$missing_task_ids, 1)
+  expect_equal(dat$missing_task_ids[[1]], "non-existent-id")
 })

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -253,7 +253,7 @@ test_that("can get status of multiple tasks without logs", {
   }
 })
 
-test_that("returns error with tasks ids of non-extant task ids", {
+test_that("returns statuses for only existent task ids", {
   # run report
   data <- list(
     name = "data",
@@ -273,7 +273,7 @@ test_that("returns error with tasks ids of non-extant task ids", {
     httr::content_type("application/json")
   )
   expect_equal(httr::status_code(r1), 200)
-  task_ids <- c(httr::content(r1)$data$taskId, "non-existant-id")
+  task_ids <- c("httr::content(r1)$data$taskId", "non-existant-id")
   
   res <- bg$request(
     "POST",
@@ -284,5 +284,8 @@ test_that("returns error with tasks ids of non-extant task ids", {
     httr::content_type("application/json")
   )
   
-  expect_equal(httr::content(res)$errors[[1]]$detail , "Job ids [non-existant-id] do not exist in the queue")
+  expect_equal(httr::status_code(res), 200)
+  dat <- httr::content(res)$data
+  expect_length(dat, 1)
+  expect_equal(dat[[1]]$taskId, task_ids[[1]])
 })


### PR DESCRIPTION
Before we would throw error if task_ids list had any task ids not found... but now we just log error and return statuses for ids that are found.

The reason for this is that the deployment of packit is taken down we lose these jobs, and packit requests these job IDs as its in the PostgreSQL database. We need to handle this case more gracefully!!! Thus packet will be able to just use database info on the missing redis task ids

This PR is twinned with https://github.com/mrc-ide/packit/pull/226.

Testing: test as per packit PR instructions