### PR TITLE
Use the metadata-action to set Docker labels.

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,20 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - id: ci-env
-        name: Setup Environment
-        shell: bash
-        run: |
-          if [ "${{github.event_name}}" = "pull_request" ];
-          then
-            long_sha=${{ github.event.pull_request.head.sha }}
-            echo "CI_BRANCH=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          else
-            long_sha=${GITHUB_SHA}
-            echo "CI_BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
-          echo "CI_SHA=${long_sha:0:7}" >> $GITHUB_OUTPUT
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -50,6 +36,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ env.GITHUB_PAT }}
 
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.TAG_DH }}
+            ghcr.io/${{ env.TAG_GHCR }}
+          tags: |
+            type=raw,value=latest,enable={{ is_default_branch }}
+            type=raw,value=${{ github.head_ref }},enable=${{ github.event_name == 'pull_request' }}
+            type=ref,event=branch
+            type=sha,prefix=
+        env:
+          # By default the SHA for PRs would refer to the temporary merge
+          # commit. We want the PR's head sha instead, since it is more useful.
+          DOCKER_METADATA_PR_HEAD_SHA: 1
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -59,8 +63,6 @@ jobs:
           pull: true
           push: true
           file: ./docker/Dockerfile
-          tags: |
-            ${{env.TAG_DH}}:${{steps.ci-env.outputs.CI_SHA}}
-            ${{env.TAG_DH}}:${{steps.ci-env.outputs.CI_BRANCH}}
-            ghcr.io/${{env.TAG_GHCR}}:${{steps.ci-env.outputs.CI_SHA}}
-            ghcr.io/${{env.TAG_GHCR}}:${{steps.ci-env.outputs.CI_BRANCH}}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
For packit-infra's automatic nightly update action, I want to be able to print a list of commits associated with the update. This isn't currently possible as there's no way to know from a Docker image the Git revision that was used to build it.

Docker labels allow us to encode extra bits of metadata in the image, such as this. Rather than re-implement all the metadata extraction and formatting, we now use the docker/metadata-action action which takes care of it all. This also replaces the old bash script that was calculating the tags to add to the image. The action needs a bit of customization to match the existing tags.

This also add `latest` as a tag for builds from the default branch, in addition to labeling them with the branch name.