### PR TITLE
Upgrade to use orderly 1.99.88

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.runner
-Title: Run an 'orderly2' Packet
-Version: 0.1.2
+Title: Run an 'orderly' Packet
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -20,7 +20,7 @@ Imports:
     gert (>= 2.0.1),
     ids,
     jsonlite,
-    orderly2 (>= 1.99.13),
+    orderly (>= 1.99.88),
     openssl,
     porcelain,
     R6,
@@ -36,6 +36,6 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Remotes:
-    mrc-ide/orderly2,
+    mrc-ide/orderly,
     reside-ic/porcelain,
     mrc-ide/rrq

--- a/R/api.R
+++ b/R/api.R
@@ -43,7 +43,7 @@ api <- function(
 ##' @porcelain GET / => json(root)
 root <- function() {
   versions <- list(
-    orderly2 = package_version_string("orderly2"),
+    orderly = package_version_string("orderly"),
     orderly.runner = package_version_string("orderly.runner")
   )
   lapply(versions, scalar)

--- a/R/reports.R
+++ b/R/reports.R
@@ -37,7 +37,7 @@ get_report_parameters <- function(name, ref, root) {
     c("show", sprintf("%s:%s", sha, path)), repo = root
   )$output
   exprs <- parse(text = contents)
-  orderly2::orderly_parse_expr(exprs, filename = basename(path))$parameters
+  orderly::orderly_parse_expr(exprs, filename = basename(path))$parameters
 }
 
 

--- a/R/runner.R
+++ b/R/runner.R
@@ -22,14 +22,14 @@ runner_run_internal <- function(url, branch, ref, reportname, parameters, locati
                           repo = repo)
   worktree <- create_temporary_worktree(repo, branch, worktree_base)
 
-  orderly2::orderly_init(worktree)
-  orderly2::orderly_location_add("upstream", location$type, location$args,
-                                 root = worktree)
+  orderly::orderly_init(worktree)
+  orderly::orderly_location_add("upstream", location$type, location$args,
+                                root = worktree)
 
-  id <- orderly2::orderly_run(reportname, parameters = parameters,
-                              fetch_metadata = TRUE, allow_remote = TRUE,
-                              location = "upstream", root = worktree, ...)
-  orderly2::orderly_location_push(id, "upstream", root = worktree)
+  id <- orderly::orderly_run(reportname, parameters = parameters,
+                             fetch_metadata = TRUE, allow_remote = TRUE,
+                             location = "upstream", root = worktree, ...)
+  orderly::orderly_location_push(id, "upstream", root = worktree)
   id
 }
 

--- a/docker/test/examples/parameters/parameters.R
+++ b/docker/test/examples/parameters/parameters.R
@@ -1,3 +1,3 @@
-orderly2::orderly_parameters(a = NULL, b = 2)
+orderly::orderly_parameters(a = NULL, b = 2)
 data <- list(a = a, b = b)
 write.csv(data, "parameters.csv")

--- a/docker/test/setup-orderly-repo
+++ b/docker/test/setup-orderly-repo
@@ -5,14 +5,14 @@ test_repo_path <- file.path(root, "docker", "test", "test-repo")
 
 gert::git_init(path = test_repo_path)
 
-orderly2::orderly_init(
+orderly::orderly_init(
     root = test_repo_path,
     use_file_store = TRUE,
     require_complete_tree = TRUE,
     force = TRUE
 )
 
-orderly2::orderly_gitignore_update("(root)", root = test_repo_path)
+orderly::orderly_gitignore_update("(root)", root = test_repo_path)
 
 gert::git_add(".", repo = test_repo_path)
 gert::git_commit("first commit", repo = test_repo_path)

--- a/inst/schema/root.json
+++ b/inst/schema/root.json
@@ -5,5 +5,5 @@
         "type": "string",
         "pattern": "^[0-9]+(\\.[0-9]+)*$"
     },
-    "required": ["orderly2", "orderly.runner"]
+    "required": ["orderly", "orderly.runner"]
 }

--- a/tests/testthat/examples/data/data.R
+++ b/tests/testthat/examples/data/data.R
@@ -1,3 +1,3 @@
-orderly2::orderly_artefact(description = "Some data", "data.rds")
+orderly::orderly_artefact(description = "Some data", "data.rds")
 d <- data.frame(a = 1:10, x = runif(10), y = 1:10 + runif(10))
 saveRDS(d, "data.rds")

--- a/tests/testthat/examples/depends/depends.R
+++ b/tests/testthat/examples/depends/depends.R
@@ -1,3 +1,3 @@
-orderly2::orderly_dependency("data", "latest", files = "data.rds")
+orderly::orderly_dependency("data", "latest", files = "data.rds")
 numbers <- readRDS("data.rds")
 saveRDS(sum(numbers), "sum.rds")

--- a/tests/testthat/examples/parameters/parameters.R
+++ b/tests/testthat/examples/parameters/parameters.R
@@ -1,2 +1,2 @@
-orderly2::orderly_parameters(a = NULL, b = 2, c = NULL)
+orderly::orderly_parameters(a = NULL, b = 2, c = NULL)
 saveRDS(list(a = a, b = b, c = c), "data.rds")

--- a/tests/testthat/helper-orderly-runner.R
+++ b/tests/testthat/helper-orderly-runner.R
@@ -50,7 +50,7 @@ empty_json_object <- function() {
 
 create_temporary_root <- function(..., env = parent.frame()) {
   path <- withr::local_tempdir(.local_envir = env)
-  suppressMessages(orderly2::orderly_init(path, ...))
+  suppressMessages(orderly::orderly_init(path, ...))
 }
 
 

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -18,7 +18,7 @@ test_that("root data returns sensible data", {
   res <- obj$request("GET", "/")
   data <- expect_success(res)
 
-  expect_true(all(c("orderly2", "orderly.runner") %in% names(data)))
+  expect_true(all(c("orderly", "orderly.runner") %in% names(data)))
   expect_match(unlist(data), "^[0-9]+\\.[0-9]+\\.[0-9]+$")
 })
 

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -81,7 +81,7 @@ test_that("can get report parameters", {
   ## Works with a specific git hash
   params_src <- file.path(root, "src", "parameters", "parameters.R")
   contents <- readLines(params_src)
-  contents <- c("orderly2::orderly_parameters(a = 'default', b = 2, c = NULL)", 
+  contents <- c("orderly::orderly_parameters(a = 'default', b = 2, c = NULL)",
                 contents[-1])
   writeLines(contents, params_src)
   sha <- git_add_and_commit(root)

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -22,7 +22,7 @@ test_that("runner runs as expected", {
   expect_true(fs::dir_exists(
     file.path(upstream_outpack, "archive", "data", id)))
 
-  info <- orderly2::orderly_metadata(id, root = upstream_outpack)$git
+  info <- orderly::orderly_metadata(id, root = upstream_outpack)$git
   expect_equal(info$branch, "master")
   expect_equal(info$sha, sha)
 })
@@ -114,11 +114,11 @@ test_that("runner can use an old commit", {
       echo = FALSE)
   }))
 
-  info1 <- orderly2::orderly_metadata(id1, root = upstream_outpack)$git
+  info1 <- orderly::orderly_metadata(id1, root = upstream_outpack)$git
   expect_equal(info1$branch, "master")
   expect_equal(info1$sha, commit1)
 
-  info2 <- orderly2::orderly_metadata(id2, root = upstream_outpack)$git
+  info2 <- orderly::orderly_metadata(id2, root = upstream_outpack)$git
   expect_equal(info2$branch, "master")
   expect_equal(info2$sha, commit2)
 })
@@ -163,7 +163,7 @@ test_that("runner can pull dependencies", {
   expect_true(fs::dir_exists(
     file.path(upstream_outpack, "archive", "depends", id2)))
 
-  info <- orderly2::orderly_metadata(id2, root = upstream_outpack)$depends
+  info <- orderly::orderly_metadata(id2, root = upstream_outpack)$depends
   expect_equal(info[1,]$packet, id1)
   expect_equal(info[1,]$query, 'latest(name == "data")')
 })

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -30,8 +30,8 @@ test_that("can run server", {
   expect_equal(dat$status, "success")
   expect_null(dat$errors)
   expect_equal(
-    dat$data$orderly2,
-    package_version_string("orderly2")
+    dat$data$orderly,
+    package_version_string("orderly")
   )
   expect_equal(
     dat$data$orderly.runner,


### PR DESCRIPTION
There's a very minor change here to the schema, this might affect packit (probably only the tests) if it relies on the exact versions returned at the root endpoint