### PR TITLE
Upgrade to 1.99.96

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.runner
 Title: Run an 'orderly' Packet
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -20,7 +20,7 @@ Imports:
     gert (>= 2.0.1),
     ids,
     jsonlite,
-    orderly (>= 1.99.88),
+    orderly (>= 1.99.96),
     openssl,
     porcelain,
     R6,

--- a/tests/testthat/helper-orderly-runner.R
+++ b/tests/testthat/helper-orderly-runner.R
@@ -59,12 +59,12 @@ test_prepare_orderly_example <- function(examples, ..., env = parent.frame()) {
   # fact that the source repository (eg. GitHub) is generally distinct from the
   # upstream outpack repository (eg. Packit).
   #
-  # We do still need to create orderly_config.yml as the bare minimum source
+  # We do still need to create orderly_config.json as the bare minimum source
   # tree.
 
   path <- withr::local_tempdir(.local_envir = env)
-  writeLines('minimum_orderly_version: "1.99.0"',
-             file.path(path, "orderly_config.yml"))
+  writeLines('{"minimum_orderly_version": "1.99.0"}',
+             file.path(path, "orderly_config.json"))
 
   copy_examples(examples, path)
 


### PR DESCRIPTION
This is the version that becomes orderly 2.0.0 (see https://github.com/mrc-ide/orderly/pull/248) and I want to see that it works with VIMC