### PR TITLE
Fix server startup in docker run-test script

### DIFF
--- a/docker/test/run-test
+++ b/docker/test/run-test
@@ -37,7 +37,6 @@ docker run --rm -d --pull=always \
        -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
        -v $ORDERLY_LOGS_VOLUME:$LOGS_DIR \
        $ORDERLY_RUNNER_IMAGE \
-       $CONTAINER_ORDERLY_ROOT_PATH \
        /repositories
 
 docker run --rm -d --pull=always \


### PR DESCRIPTION
The `run-test` script has been broken since [5b11ef6](https://github.com/mrc-ide/orderly.runner/commit/5b11ef61105ccb4fd877d6729fadbf6083609ad4) because it passed two arguments to `bin/orderly.runner.server` (the server CLI) instead of one -- that commit changed things so that it requires only one argument, the path to find where git clones of repos are stored.

We need to not pass the argument `/orderly-root` to the server startup command. It is still needed for the _worker_ startup command, since after that earlier refactoring commit, workers each have their own orderly root.