### PR TITLE
Add missing documentation

### DIFF
--- a/man/api.Rd
+++ b/man/api.Rd
@@ -26,6 +26,8 @@ environments.  See \link[porcelain:porcelain]{porcelain::porcelain} for details}
 \item{lib_path}{Path to library to list packages from in
 the /library/list endpoint. This is expected to be a shared library
 that workers have access to, mounted from the host machine.
+It should only be used for testing, since the workers have a hard-coded
+library mountpoint path of "/library" (as per Dockerfile).
 See https://github.com/vimc/montagu-config/tree/main/packages
 for more details.}
 


### PR DESCRIPTION
I had forgotten to run `devtools::document()` after making an update to an endpoint-documenting string (in `api.R`). As a result, the extra sentence did not appear in the automatically generated `api.Rmd`, nor on the github pages [documentation](https://mrc-ide.github.io/orderly.runner/) for orderly.runner.