### PR TITLE
Simplify the docker run test script

### DIFF
--- a/docker/test/run-test
+++ b/docker/test/run-test
@@ -22,14 +22,14 @@ docker volume create $LIBRARY_VOLUME
 # Install a test package into the library volume,
 # to be returned by the library_list API endpoint.
 docker run --rm --pull=missing \
-       -v $LIBRARY_VOLUME:$LIBRARY_MOUNT_PATH \
+       --volume=$LIBRARY_VOLUME:$LIBRARY_MOUNT_PATH \
        $ORDERLY_RUNNER_IMAGE \
        Rscript -e "install.packages('mime', lib='$LIBRARY_MOUNT_PATH')"
 
 docker run --rm -d --pull=missing \
        --name=$DEBUG \
-       -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
-       -v $ORDERLY_LOGS_VOLUME:$LOGS_DIR \
+       --volume=$ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
+       --volume=$ORDERLY_LOGS_VOLUME:$LOGS_DIR \
        ubuntu \
        sleep infinity
 
@@ -42,9 +42,9 @@ docker run --rm -d --pull=always \
        --env=ORDERLY_RUNNER_QUEUE_ID=$ORDERLY_RUNNER_QUEUE_ID \
        --env=REDIS_URL=redis://$REDIS \
        -p 127.0.0.1:8001:8001 \
-       -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
-       -v $ORDERLY_LOGS_VOLUME:$LOGS_DIR \
-       -v $LIBRARY_VOLUME:$LIBRARY_MOUNT_PATH \
+       --volume=$ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
+       --volume=$ORDERLY_LOGS_VOLUME:$LOGS_DIR \
+       --volume=$LIBRARY_VOLUME:$LIBRARY_MOUNT_PATH \
        $ORDERLY_RUNNER_IMAGE \
        /repositories
 
@@ -54,8 +54,6 @@ docker run --rm -d --pull=always \
        --entrypoint="/usr/local/bin/orderly.runner.worker" \
        --env=ORDERLY_RUNNER_QUEUE_ID=$ORDERLY_RUNNER_QUEUE_ID \
        --env=REDIS_URL=redis://$REDIS \
-       -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
-       -v $ORDERLY_LOGS_VOLUME:$LOGS_DIR \
-       -v $LIBRARY_VOLUME:$LIBRARY_MOUNT_PATH \
+       --volumes-from=$SERVER \
        $ORDERLY_RUNNER_IMAGE \
        $CONTAINER_ORDERLY_ROOT_PATH


### PR DESCRIPTION
Use 'volumes-from' arg to reduce duplication; use full-name flags instead of '-v' to make it easier to read for noobs