### PR TITLE
Fix test warnings

### DIFF
--- a/docker/test/examples/parameters/parameters.R
+++ b/docker/test/examples/parameters/parameters.R
@@ -1,3 +1,3 @@
-orderly::orderly_parameters(a = NULL, b = 2)
-data <- list(a = a, b = b)
+pars <- orderly::orderly_parameters(a = NULL, b = 2)
+data <- list(a = pars$a, b = pars$b)
 write.csv(data, "parameters.csv")

--- a/tests/testthat/examples/parameters/parameters.R
+++ b/tests/testthat/examples/parameters/parameters.R
@@ -1,2 +1,2 @@
-orderly::orderly_parameters(a = NULL, b = 2, c = NULL)
-saveRDS(list(a = a, b = b, c = c), "data.rds")
+pars <- orderly::orderly_parameters(a = NULL, b = 2, c = NULL)
+saveRDS(list(a = pars$a, b = pars$b, c = pars$c), "data.rds")

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -203,10 +203,10 @@ test_that("can list orderly reports", {
   ## Can list items from this sha
   res <- obj$request("GET", "/report/list", query = list(url = upstream,
                                                          ref = sha))
-  other_data <- expect_success(res)
-  params2 <- other_data[other_data$name == "parameters2", ]
-  existing <- res$data[other_data$name != "parameters2", ]
-  expect_equal(existing, res$data)
+  new_data <- expect_success(res)
+  params2 <- new_data[new_data$name == "parameters2", ]
+  preexisting <- new_data[new_data$name != "parameters2", ]
+  expect_equal(preexisting, data)
   expect_equal(nrow(params2), 1)
   expect_true(params2$hasModifications)
 

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -194,7 +194,7 @@ test_that("only returns existent status of task_ids", {
 
   task_ids <- c(r1, "non-existent-id")
 
-  res <- q$get_status(task_ids, include_logs = FALSE)
+  res <- suppressWarnings(q$get_status(task_ids, include_logs = FALSE))
 
   expect_length(res$statuses, 1)
   expect_equal(res$statuses[[1]]$taskId, scalar(task_ids[[1]]))

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -81,13 +81,13 @@ test_that("can get report parameters", {
   ## Works with a specific git hash
   params_src <- file.path(root, "src", "parameters", "parameters.R")
   contents <- readLines(params_src)
-  contents <- c("orderly::orderly_parameters(a = 'default', b = 2, c = NULL)",
+  contents <- c("pars <- orderly::orderly_parameters(a = 'd', b = 2, c = NULL)",
                 contents[-1])
   writeLines(contents, params_src)
   sha <- git_add_and_commit(root)
   
   params_new <- get_report_parameters("parameters", sha, root)
-  expect_equal(params_new, list(a = "default",
+  expect_equal(params_new, list(a = "d",
                                 b = 2,
                                 c = NULL))
   

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -26,7 +26,8 @@ on.exit(bg$stop())
 install.packages(
   "mime",
   lib = library_path,
-  repos = "https://cloud.r-project.org"
+  repos = "https://cloud.r-project.org",
+  quiet = TRUE,
 )
 
 r <- bg$request("POST",


### PR DESCRIPTION
There were lots of warnings in test output, which was polluting test outputs making them rather difficult to read.

Most of these were orderly warnings about a deprecated syntax.

> You must assign calls to 'orderly_parameters()' to a variable
>  i The old behaviour of automatically copying parameters into the environment has been deprecated, and you should move to the new behaviour as soon as possible

Also: suppressed an expected warning - that line deliberately requests a non-existent job.
  