### PR TITLE
Include all packages in /library/list return value, and report packages' install location

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.runner
 Title: Run an 'orderly' Packet
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -8,7 +8,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
 Description: Small HTTP server for running orderly reports.
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "porcelain::porcelain_roclet"))
 URL: https://github.com/mrc-ide/orderly.runner
 BugReports: https://github.com/mrc-ide/orderly.runner/issues

--- a/R/api.R
+++ b/R/api.R
@@ -22,14 +22,6 @@
 ##' @param skip_queue_creation Skip queue creation, this is primarily
 ##'   used for tests where we can't establish a Redis connection.
 ##'
-##' @param lib_path Path to library to list packages from in
-##'   the /library/list endpoint. This is expected to be a shared library
-##'   that workers have access to, mounted from the host machine.
-##'   It should only be used for testing, since the workers have a hard-coded
-##'   library mountpoint path of "/library" (as per Dockerfile).
-##'   See https://github.com/vimc/montagu-config/tree/main/packages
-##'   for more details.
-##'
 ##' @return A [porcelain::porcelain] object. Notably this does *not*
 ##'   start the server
 ##'
@@ -38,7 +30,6 @@ api <- function(
     repositories_base_path,
     validate = NULL,
     log_level = "info",
-    lib_path = "/library",
     skip_queue_creation = FALSE) {
   logger <- porcelain::porcelain_logger(log_level)
 
@@ -52,8 +43,8 @@ api <- function(
   api <- porcelain::porcelain$new(validate = validate, logger = logger)
   api$include_package_endpoints(state = list(
     repositories_base_path = repositories_base_path,
-    queue = queue,
-    lib_path = lib_path))
+    queue = queue
+  ))
   api
 }
 
@@ -69,12 +60,12 @@ root <- function() {
 
 
 ##' @porcelain GET /library/list => json(library_list)
-##'   state lib_path :: lib_path
-library_list <- function(lib_path) {
-  pkgs <- installed.packages(lib.loc = lib_path, noCache = TRUE)
+library_list <- function() {
+  pkgs <- installed.packages(noCache = TRUE)
   data.frame(
     name = unname(pkgs[, "Package"]),
-    version = unname(pkgs[, "Version"])
+    version = unname(pkgs[, "Version"]),
+    location = unname(pkgs[, "LibPath"])
   )
 }
 

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -14,7 +14,6 @@
         "GET",
         "/library/list",
         library_list,
-        porcelain::porcelain_state(lib_path = state$lib_path),
         returning = porcelain::porcelain_returning_json("library_list"),
         validate = validate)
     },

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To run a redis container, use `scripts/redis start`. Bring it down with `scripts
 ## To run the full docker setup
 
 1. Optionally modify `docker/test/examples` orderly reports. These will be used as reports in the container
+1. Clear the decks with `docker/test/clear-test`.
 1. Run `docker/test/run-test` to use the docker image from GitHub Container Registry, or `docker/test/run-test --local` to build from your local version for development. This will produce a `test-repo` directory to show you what was copied into the docker containers (you can create just this directory without running the docker containers by running `docker/test/setup-test-repo` if you want).
 1. The server will be available at `localhost:8001`
 1. To view the orderly root directory in the docker container (you may want to do this after workers have run orderly reports for example), run `docker/test/copy-orderly-root` and this will copy the contents to `docker/test/orderly-root-volume`

--- a/docker/test/run-test
+++ b/docker/test/run-test
@@ -27,13 +27,6 @@ docker volume create $ORDERLY_VOLUME
 docker volume create $ORDERLY_LOGS_VOLUME
 docker volume create $LIBRARY_VOLUME
 
-# Install a test package into the library volume,
-# to be returned by the library_list API endpoint.
-docker run --rm --pull=$PULL_POLICY \
-       --volume=$LIBRARY_VOLUME:$LIBRARY_MOUNT_PATH \
-       $ORDERLY_RUNNER_IMAGE \
-       Rscript -e "install.packages('mime', lib='$LIBRARY_MOUNT_PATH')"
-
 docker run --rm -d --pull=missing \
        --name=$DEBUG \
        --volume=$ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \

--- a/inst/schema/library_list.json
+++ b/inst/schema/library_list.json
@@ -5,10 +5,11 @@
         "type": "object",
         "properties": {
             "name": { "type": "string" },
-            "version": { "type": "string" }
+            "version": { "type": "string" },
+            "location": { "type": "string" }
         },
         "additionalProperties": false,
-        "required": ["name", "version"]
+        "required": ["name", "version", "location"]
     }
 }
 

--- a/man/api.Rd
+++ b/man/api.Rd
@@ -8,7 +8,6 @@ api(
   repositories_base_path,
   validate = NULL,
   log_level = "info",
-  lib_path = "/library",
   skip_queue_creation = FALSE
 )
 }
@@ -22,14 +21,6 @@ environments.  See \link[porcelain:porcelain]{porcelain::porcelain} for details}
 
 \item{log_level}{Logging level to use. Sensible options are "off",
 "info" and "all".}
-
-\item{lib_path}{Path to library to list packages from in
-the /library/list endpoint. This is expected to be a shared library
-that workers have access to, mounted from the host machine.
-It should only be used for testing, since the workers have a hard-coded
-library mountpoint path of "/library" (as per Dockerfile).
-See https://github.com/vimc/montagu-config/tree/main/packages
-for more details.}
 
 \item{skip_queue_creation}{Skip queue creation, this is primarily
 used for tests where we can't establish a Redis connection.}

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -35,16 +35,12 @@ test_that("can list installed libraries from default library path /library", {
 })
 
 test_that("can list installed libraries from custom library path", {
-  # Set lib_path to the parent library directory of the testthat package,
-  # which is guaranteed to be installed, since we are using it here.
-  pkg_path <- find.package("testthat")
-  lib_path <- dirname(pkg_path)
-
-  obj <- create_api(skip_queue_creation = TRUE, lib_path = lib_path)
+  obj <- create_api(skip_queue_creation = TRUE)
 
   res <- obj$request("GET", "/library/list")
   data <- expect_success(res)
 
+  # The testthat package is guaranteed to be installed, since we use it here.
   expect_true("testthat" %in% data$name)
   expect_true(
     as.character(packageVersion("testthat")) %in%

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -23,18 +23,7 @@ test_that("root data returns sensible data", {
 })
 
 
-test_that("can list installed libraries from default library path /library", {
-  obj <- create_api(skip_queue_creation = TRUE)
-
-  res <- obj$request("GET", "/library/list")
-  data <- expect_success(res)
-
-  # The /library mountpoint does not exist unless the API was set up using
-  # the Docker container, so the response is an empty list
-  expect_equal(data, list())
-})
-
-test_that("can list installed libraries from custom library path", {
+test_that("can list installed libraries", {
   obj <- create_api(skip_queue_creation = TRUE)
 
   res <- obj$request("GET", "/library/list")

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -15,15 +15,6 @@ bg <- porcelain::porcelain_background$new(
 bg$start()
 on.exit(bg$stop())
 
-library_path <- withr::local_tempdir()
-# Install a small package in a temp dir for testing
-install.packages(
-  "mime",
-  lib = library_path,
-  repos = "https://cloud.r-project.org",
-  quiet = TRUE,
-)
-
 r <- bg$request("POST",
                 "/repository/fetch",
                 query = list(url = upstream_git),
@@ -61,10 +52,12 @@ test_that("can list installed libraries", {
   versions <- vapply(dat$data, function(x) x$version, "")
   locations <- vapply(dat$data, function(x) x$location, "")
 
-  expect_true("mime" %in% packages)
-  mime_version <- versions[packages == "mime"]
-  expect_match(mime_version, "^[0-9]+\\.[0-9]+")
-  expect_equal(locations[packages == "mime"], library_path)
+  # Check that orderly.runner is among the list of installed packages
+  expect_true("orderly.runner" %in% packages)
+  idx <- which(packages == "orderly.runner")
+  expect_match(versions[idx], "^[0-9]+\\.[0-9]+")
+  # Check location is a non-empty path
+  expect_true(nzchar(locations[idx]))
 })
 
 

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -7,22 +7,16 @@ queue <- start_queue_with_workers(1, queue_id = queue_id)
 upstream_git <- test_prepare_orderly_example(c("data", "parameters"))
 upstream_outpack <- create_temporary_root(use_file_store = TRUE)
 
-library_path <- withr::local_tempdir()
-
 bg <- porcelain::porcelain_background$new(
   api,
-  args = list(
-    repositories_base_path = withr::local_tempdir(),
-    lib_path = library_path
-  ),
+  args = list(repositories_base_path = withr::local_tempdir()),
   env = c(ORDERLY_RUNNER_QUEUE_ID = queue_id)
 )
 bg$start()
 on.exit(bg$stop())
 
-# Install a small package at library_path
-# TODO: Once an 'install package' endpoint is implemented, this can be done
-# via the API instead of directly here
+library_path <- withr::local_tempdir()
+# Install a small package in a temp dir for testing
 install.packages(
   "mime",
   lib = library_path,
@@ -65,11 +59,12 @@ test_that("can list installed libraries", {
 
   packages <- vapply(dat$data, function(x) x$name, "")
   versions <- vapply(dat$data, function(x) x$version, "")
+  locations <- vapply(dat$data, function(x) x$location, "")
 
   expect_true("mime" %in% packages)
   mime_version <- versions[packages == "mime"]
   expect_match(mime_version, "^[0-9]+\\.[0-9]+")
-
+  expect_equal(locations[packages == "mime"], library_path)
 })
 
 

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -57,7 +57,9 @@ test_that("can list installed libraries", {
   idx <- which(packages == "orderly.runner")
   expect_match(versions[idx], "^[0-9]+\\.[0-9]+")
   # Check location is a non-empty path
-  expect_true(nzchar(locations[idx]))
+  # ('all' covers the case where orderly.runner is installed in
+  # multiple locations)
+  expect_true(all(nzchar(locations[idx])))
 })
 
 


### PR DESCRIPTION
Updates the endpoint to report not only the list of R packages (with versions) installed in the shared library mounted at `/library`, but instead report _all_ installed packages, their versions, and (new!) their locations.

An alternative design would have been to report two lists, divided into 'those installed in the specified location (shared, additional packages)' and 'those installed elsewhere (core)'. I prefer reporting all locations, for increased generality; that is to say, if we want to split the packages into two lists, we can do that further downstream (i.e. in packit itself), or indeed if we don't want to we don't have to.

Don't merge this until the packit PR https://github.com/mrc-ide/packit/pull/263 is ready to merge: packit currently expects to only be told about packages installed in the shared R library.

### Implementation/changes

`lib_path` used to be a parameter you could pass to the API (the porcelain controller, as it were) to tell our endpoint where to look for packages. Now that we report back all packages, we don't need to set this any more, so the parameter is removed, and things are simpler, and fewer unit tests are needed

